### PR TITLE
Prevent duplicate allocations

### DIFF
--- a/spec/models/allocation_registry_spec.rb
+++ b/spec/models/allocation_registry_spec.rb
@@ -91,4 +91,23 @@ RSpec.describe FlightScheduler::AllocationRegistry, type: :model do
       end
     end
   end
+
+  describe 'allocation conflict' do
+    specify 'allocating an already allocated node raises an AllocationConflict' do
+      job1 = make_job(1, 1)
+      job2 = make_job(2, 1)
+      add_allocation(job1, nodes[0...1])
+
+      expect { add_allocation(job2, nodes[0...1]) }.to raise_exception \
+        FlightScheduler::AllocationRegistry::AllocationConflict
+    end
+
+    specify 'allocating an already allocated job raises an AllocationConflict' do
+      job = make_job(1, 1)
+      add_allocation(job, nodes[0...1])
+
+      expect { add_allocation(job, nodes[1...2]) }.to raise_exception \
+        FlightScheduler::AllocationRegistry::AllocationConflict
+    end
+  end
 end

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Partition, type: :scheduler do
         2.times.each do |job_id|
           job = make_job(job_id, 1)
           scheduler.add_job(job)
-          add_allocation(job, nodes[0...1])
+          add_allocation(job, [nodes[job_id]])
         end
       }
 


### PR DESCRIPTION
Currently, a job can have a single allocation and a node can have a single allocation.