### PR TITLE
Various server side incompatibility fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,11 +39,11 @@ gem 'sinatra-cors'
 gem 'sinja', '>= 1.3.0'
 gem 'swagger-blocks'
 
-group 'development' do
+group :development do
   gem 'pry'
   gem 'pry-byebug'
-end
 
-group :test do
-  gem 'rspec'
+  group :test do
+    gem 'rspec'
+  end
 end

--- a/app.rb
+++ b/app.rb
@@ -59,13 +59,6 @@ class App < Sinatra::Base
           items { key :type, :string }
         end
       end
-      property :relationships do
-        property :schedular do
-          property :data do
-            key :'$ref', :rioSchedular
-          end
-        end
-      end
     end
 
     swagger_schema :rioPartition do
@@ -121,13 +114,6 @@ class App < Sinatra::Base
           key :type, :string
         end
       end
-      property :relationships do
-        property :schedular do
-          property :data do
-            key :'$ref', :rioSchedular
-          end
-        end
-      end
     end
 
     swagger_schema :newJob do
@@ -136,20 +122,19 @@ class App < Sinatra::Base
         key :value, 'jobs'
       end
       property :attributes do
-        property :min_nodes do
-          key :type, :integer
-          key :nullable, true
-          key :minimum, 1
+        property :'min-nodes' do
+          one_of do
+            key :type, :string
+            key :pattern, '^\d+[km]?$'
+          end
+          one_of do
+            key :type, :integer
+            key :nullable, true
+            key :minimum, 1
+          end
         end
         property :script do
           key :type, :string
-        end
-      end
-      property :relationships do
-        property :schedular do
-          property :data do
-            key :'$ref', :rioSchedular
-          end
         end
       end
     end

--- a/app.rb
+++ b/app.rb
@@ -196,7 +196,7 @@ class App < Sinatra::Base
 
     helpers do
       def find(id)
-        PARTITIONS.map { |p| p.jobs }.flatten.find { |j| j.id == id }
+        FlightScheduler.app.scheduler.queue.find { |j| j.id == id }
       end
 
       def validate!
@@ -222,7 +222,7 @@ class App < Sinatra::Base
     end
 
     destroy do
-      resource.clear
+      FlightScheduler.app.scheduler.remove_job(resource)
     end
   end
 

--- a/app.rb
+++ b/app.rb
@@ -88,10 +88,8 @@ class App < Sinatra::Base
       end
     end
 
-    helpers do
-      index do
-        FlightScheduler.app.partitions
-      end
+    index do
+      FlightScheduler.app.partitions
     end
   end
 

--- a/app.rb
+++ b/app.rb
@@ -114,6 +114,13 @@ class App < Sinatra::Base
           key :type, :string
         end
       end
+      property :relationships do
+        property :partition do
+          property :data do
+            key :'$ref', :rioPartition
+          end
+        end
+      end
     end
 
     swagger_schema :newJob do

--- a/app.rb
+++ b/app.rb
@@ -127,6 +127,7 @@ class App < Sinatra::Base
         key :value, 'jobs'
       end
       property :attributes do
+        key :required, [:'min-nodes', :script]
         property :'min-nodes' do
           one_of do
             key :type, :string
@@ -134,7 +135,6 @@ class App < Sinatra::Base
           end
           one_of do
             key :type, :integer
-            key :nullable, true
             key :minimum, 1
           end
         end

--- a/app.rb
+++ b/app.rb
@@ -127,7 +127,7 @@ class App < Sinatra::Base
         key :value, 'jobs'
       end
       property :attributes do
-        key :required, [:'min-nodes', :script]
+        key :required, [:'min-nodes', :script, :args]
         property :'min-nodes' do
           one_of do
             key :type, :string
@@ -140,6 +140,12 @@ class App < Sinatra::Base
         end
         property :script do
           key :type, :string
+        end
+        property :args do
+          key :type, :array
+          items do
+            key :type, :string
+          end
         end
       end
     end
@@ -214,6 +220,7 @@ class App < Sinatra::Base
         min_nodes: attr[:min_nodes],
         partition: FlightScheduler.app.default_partition,
         script: attr[:script],
+        args: attr[:args],
         state: 'pending',
       )
       FlightScheduler.app.scheduler.add_job(job)

--- a/app.rb
+++ b/app.rb
@@ -127,7 +127,7 @@ class App < Sinatra::Base
         key :value, 'jobs'
       end
       property :attributes do
-        key :required, [:'min-nodes', :script, :args]
+        key :required, [:'min-nodes', :script, :arguments]
         property :'min-nodes' do
           one_of do
             key :type, :string
@@ -141,7 +141,7 @@ class App < Sinatra::Base
         property :script do
           key :type, :string
         end
-        property :args do
+        property :arguments do
           key :type, :array
           items do
             key :type, :string
@@ -220,7 +220,7 @@ class App < Sinatra::Base
         min_nodes: attr[:min_nodes],
         partition: FlightScheduler.app.default_partition,
         script: attr[:script],
-        args: attr[:args],
+        arguments: attr[:arguments],
         state: 'pending',
       )
       FlightScheduler.app.scheduler.add_job(job)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -38,14 +38,18 @@ class Job
 
   # Handle the k and m suffix
   attr_reader :min_nodes
-  def min_nodes=(num)
-    str = num.to_s
-    @min_nodes ||= if /\A\d+k\Z/.match?(str)
+
+  def min_nodes=(raw)
+    str = raw.to_s
+    @min_nodes = if /\A\d+k\Z/.match?(str)
       str.sub('k', '').to_i * 1024
     elsif /\A\d+m\Z/.match(str)
       str.sub('m', '').to_i * 1048576
+    elsif /\d+/.match?(str)
+      str.to_i
     else
-      num
+      # This will error during validation with an appropriate error message
+      str
     end
   end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -34,7 +34,6 @@ class Job
   attr_accessor :partition
   attr_accessor :script
   attr_accessor :state
-  attr_accessor :args
 
   # Handle the k and m suffix
   attr_reader :min_nodes

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -45,7 +45,7 @@ class Job
       str.sub('k', '').to_i * 1024
     elsif /\A\d+m\Z/.match(str)
       str.sub('m', '').to_i * 1048576
-    elsif /\d+/.match?(str)
+    elsif /\A\d+\Z/.match?(str)
       str.to_i
     else
       # This will error during validation with an appropriate error message

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -31,7 +31,6 @@ class Job
 
   attr_accessor :arguments
   attr_accessor :id
-  attr_accessor :min_nodes
   attr_accessor :partition
   attr_accessor :script
   attr_accessor :state

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -34,6 +34,7 @@ class Job
   attr_accessor :partition
   attr_accessor :script
   attr_accessor :state
+  attr_accessor :args
 
   # Handle the k and m suffix
   attr_reader :min_nodes

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -36,6 +36,19 @@ class Job
   attr_accessor :script
   attr_accessor :state
 
+  # Handle the k and m suffix
+  attr_reader :min_nodes
+  def min_nodes=(num)
+    str = num.to_s
+    @min_nodes ||= if /\A\d+k\Z/.match?(str)
+      str.sub('k', '').to_i * 1024
+    elsif /\A\d+m\Z/.match(str)
+      str.sub('m', '').to_i * 1048576
+    else
+      num
+    end
+  end
+
   validates :id, presence: true
   validates :min_nodes,
     presence: true,

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -38,8 +38,8 @@ class Partition
   # insufficient nodes available.
   def available_nodes_for(job)
     available_nodes = nodes.select { |node| node.satisfies?(job) }
-    if available_nodes.length >= job.min_nodes
-      available_nodes[0...job.min_nodes]
+    if available_nodes.length >= job.min_nodes.to_i
+      available_nodes[0...job.min_nodes.to_i]
     else
       nil
     end

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -38,8 +38,8 @@ class Partition
   # insufficient nodes available.
   def available_nodes_for(job)
     available_nodes = nodes.select { |node| node.satisfies?(job) }
-    if available_nodes.length >= job.min_nodes.to_i
-      available_nodes[0...job.min_nodes.to_i]
+    if available_nodes.length >= job.min_nodes
+      available_nodes[0...job.min_nodes]
     else
       nil
     end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -39,16 +39,6 @@ class PartitionSerializer < BaseSerializer
   end
 end
 
-class SchedularSerializer < BaseSerializer
-  def id
-    object.name
-  end
-  attribute :name
-
-  has_many :jobs
-  has_one :partition
-end
-
 class JobSerializer < BaseSerializer
   attribute(:min_nodes) { object.min_nodes.to_i }
   attribute :script

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -50,7 +50,7 @@ class SchedularSerializer < BaseSerializer
 end
 
 class JobSerializer < BaseSerializer
-  attribute :min_nodes
+  attribute(:min_nodes) { object.min_nodes.to_i }
   attribute :script
   has_one :schedular
 end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -52,5 +52,4 @@ end
 class JobSerializer < BaseSerializer
   attribute(:min_nodes) { object.min_nodes.to_i }
   attribute :script
-  has_one :schedular
 end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -40,7 +40,7 @@ class PartitionSerializer < BaseSerializer
 end
 
 class JobSerializer < BaseSerializer
-  attribute(:min_nodes) { object.min_nodes.to_i }
+  attribute :min_nodes
   attribute :script
 
   has_one :partition

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -42,4 +42,6 @@ end
 class JobSerializer < BaseSerializer
   attribute(:min_nodes) { object.min_nodes.to_i }
   attribute :script
+
+  has_one :partition
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Job, type: :model do
 
       it { is_expected.to be_valid }
 
-      it 'returns the string' do
-        expect(subject.min_nodes).to eq(input_min_nodes)
+      it 'returns the integer' do
+        expect(subject.min_nodes).to eq(input_min_nodes.to_i)
       end
     end
 

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -26,26 +26,45 @@
 #==============================================================================
 require 'spec_helper'
 
-RSpec.describe Node, type: :model do
-  subject { Node.new(name: 'node01') }
-  let(:job) {
-    Job.new(
-      id: 1,
-      min_nodes: 1,
-      script: '/some/path',
-      arguments: [],
-    )
-  }
+RSpec.describe Job, type: :model do
+  describe '#min_nodes' do
+    let(:input_min_nodes) { raise NotImplementedError }
 
-  describe 'job satisfaction' do
-    it 'satisfies a job if it is not allocated' do
-      allow(subject).to receive(:allocation).and_return nil
-      expect(subject.satisfies?(job)).to be true
+    subject do
+      described_class.new(id: SecureRandom.uuid,
+                          script: '/bin/foo',
+                          state: 'pending',
+                          min_nodes: input_min_nodes)
     end
 
-    it 'does not satisfy a job if it is allocated' do
-      allow(subject).to receive(:allocation).and_return Object.new
-      expect(subject.satisfies?(job)).to be false
+    context 'when it is an integer string' do
+      let(:input_min_nodes) { '10' }
+
+      it { is_expected.to be_valid }
+
+      it 'returns the string' do
+        expect(subject.min_nodes).to eq(input_min_nodes)
+      end
+    end
+
+    context 'when it is a "k" (x1024) multiple' do
+      let(:input_min_nodes) { '10k' }
+
+      it { is_expected.to be_valid }
+
+      it 'returns the multiple as an integer' do
+        expect(subject.min_nodes).to eq(input_min_nodes.gsub('k', '').to_i * 1024)
+      end
+    end
+
+    context 'when it is a "m" (x1048576) multiple' do
+      let(:input_min_nodes) { '10m' }
+
+      it { is_expected.to be_valid }
+
+      it 'returns the multiple as an integer' do
+        expect(subject.min_nodes).to eq(input_min_nodes.gsub('m', '').to_i * 1048576)
+      end
     end
   end
 end

--- a/spec/models/partition_spec.rb
+++ b/spec/models/partition_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Partition, type: :model do
   let(:job) {
     Job.new(
       id: 1,
-      min_nodes: 2,
+      min_nodes: '2',
       script: '/some/path',
       arguments: [],
     )


### PR DESCRIPTION
This PR is to track various changes required to the server so it behaves nicely.

Fix 1: Allow `jobs` to be created from a string version of `min_nodes`. Previously it was returning the following error:
```
bin/scheduler: The API returned a 403 error status and this content:
  {
    "errors": [
      {
        "id": "2d7c77c5-8b21-41c6-94f3-d9f1849686e8",
        "title": "Forbidden Error",
        "detail": "Client-generated ID not provided",
        "status": "403"
      }
    ]
  }
```
This is a red herring, there is no  "client generated ID" issue. Instead an `ArgumentError` has been raised as `min_nodes` was supplies as a `string` instead of an `integer`. The client now allows `k` and `m` suffixes to `min_nodes` and ipso facto submits everything as a string. Two  changes have been made in regard to this:
* The server now converts the `k` and `m` so that `min_nodes` ends up as an `integer` https://github.com/openflighthpc/flight-scheduler-controller/commit/e3dd8a695290f89c4c0befec3f7b917960c3d2ad
* The server now allows `min_nodes` to be a string version of an integer when the suffix is omitted: https://github.com/openflighthpc/flight-scheduler-controller/commit/4d684feeae7ac162c7748d9c3df1f3242f368d9d

Fix 2: Serialise Job against Partition instead of Scheduler
This has been done in various commits and is reasonable straight forward. The `Scheduler` model has been removed entirely and instead each `Job` is directly linked to a `Partition`.

Fix 3: Update the find method for jobs
The following error was previously returned:
```
bin/scheduler: The API returned a 500 error status and this content:
  {
    "errors": [
      {
        "id": "b952ecc1-58b1-4f72-8fb0-157fc41c74df",
        "title": "Name Error",
        "detail": "uninitialized constant App::PARTITIONS\nDid you mean?  Partition",
        "status": "500"
      }
    ]
  }
```
Also allow jobs to be cancelled using the new `FlightScheduler`: https://github.com/openflighthpc/flight-scheduler-controller/pull/2/commits/41951b1ba702e79d081861713746958f18f8827b
