### PR TITLE
Job cancellation for running jobs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -224,7 +224,7 @@ class App < Sinatra::Base
         partition: FlightScheduler.app.default_partition,
         script: attr[:script],
         arguments: attr[:arguments],
-        state: 'pending',
+        state: 'PENDING',
       )
       next job.id, job
     end

--- a/app.rb
+++ b/app.rb
@@ -230,7 +230,7 @@ class App < Sinatra::Base
     end
 
     destroy do
-      FlightScheduler.app.scheduler.remove_job(resource)
+      FlightScheduler.app.event_processor.cancel_job(resource)
     end
   end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -29,6 +29,11 @@ require 'active_model'
 class Job
   include ActiveModel::Model
 
+  STATES = %w( PENDING RUNNING CANCELLED COMPLETED FAILED )
+  STATES.each do |s|
+    define_method("#{s.downcase}?") { self.state == s }
+  end
+
   attr_writer :arguments
   attr_accessor :id
   attr_accessor :partition
@@ -59,7 +64,7 @@ class Job
   validates :script, presence: true
   validates :state,
     presence: true,
-    inclusion: { within: %w( pending running cancelled completed failed ) }
+    inclusion: { within: STATES }
 
   def allocation
     FlightScheduler.app.allocations.for_job(self.id)

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -29,6 +29,7 @@ require 'async/websocket/adapters/rack'
 
 class MessageProcessor
   attr_reader :connection
+  attr_reader :node_name
 
   def initialize(node_name, connection)
     @node_name = node_name
@@ -71,6 +72,7 @@ class WebsocketApp
         Async.logger.info("#{node.inspect} connected")
         processor = MessageProcessor.new(node, connection)
         connections.add(node, processor)
+        Async.logger.debug("Connected nodes #{connections.connected_nodes}")
         while message = connection.read
           processor.call(message)
         end
@@ -78,6 +80,7 @@ class WebsocketApp
       ensure
         Async.logger.info("#{node.inspect} disconnected")
         connections.remove(processor)
+        Async.logger.debug("Connected nodes #{connections.connected_nodes}")
       end
     end
   end

--- a/lib/flight_scheduler/daemon_connections.rb
+++ b/lib/flight_scheduler/daemon_connections.rb
@@ -40,13 +40,15 @@ class DaemonConnections
     FlightScheduler.app.event_processor.node_connected
   end
 
-  def remove(processor_to_remove)
-    @connections.delete_if do |_, processor|
-      processor == processor_to_remove
-    end
+  def remove(processor)
+    @connections.delete(processor.node_name)
   end
 
   def [](node_name)
     @connections[node_name]
+  end
+
+  def connected_nodes
+    @connections.keys
   end
 end

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -45,6 +45,16 @@ module FlightScheduler::EventProcessor
 
   def allocate_resources_and_run_jobs
     Async.logger.info("Attempting to allocate rescources to jobs")
+    Async.logger.debug("Queued jobs #{FlightScheduler.app.scheduler.queue.map(&:id)}")
+    Async.logger.debug(
+      "Allocated jobs #{FlightScheduler.app.allocations.each.map{|a| a.job.id}}"
+    )
+    Async.logger.debug(
+      "Connected nodes #{FlightScheduler.app.daemon_connections.connected_nodes}"
+    )
+    Async.logger.debug(
+      "Allocated nodes #{FlightScheduler.app.allocations.each.map{|a| a.nodes.map(&:name)}.flatten.sort.uniq}"
+    )
     new_allocations = FlightScheduler.app.scheduler.allocate_jobs
     new_allocations.each do |allocation|
       allocated_nodes = allocation.nodes.map(&:name).join(',')

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -60,7 +60,7 @@ class FifoScheduler
     new_allocations = []
     @allocation_mutex.synchronize do
       loop do
-        next_job = @queue.detect { |job| job.allocation.nil? }
+        next_job = @queue.detect { |job| job.allocation.nil? && job.pending? }
         break if next_job.nil?
         allocation = allocate_job(next_job)
         break if allocation.nil?

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Job, type: :model do
     subject do
       described_class.new(id: SecureRandom.uuid,
                           script: '/bin/foo',
-                          state: 'pending',
+                          state: 'PENDING',
                           min_nodes: input_min_nodes)
     end
 


### PR DESCRIPTION
The first commit fixes some issues with handling daemon disconnection.  The second commit implements job cancellation.

Job cancellation is supported for both `pending` and `running` jobs.  For `pending` jobs the job is marked as `cancelled` and removed from the queue.  For `running` jobs the job is marked as `cancelled` and a message sent to any nodes allocated to it to cancel the job.  When a job completed or job failed message is processed, if its state is already `cancelled` it is not updated.

The code in `cancel_job` is quite similar to the code in `allocate_resources_and_run_jobs`.  I suspect that they will diverge as error handling is added and support for more execution strategies are added; e.g., array tasks and non-array tasks on multiple nodes.  As such removing the duplication would likely be premature at this point.