### PR TITLE
Seraialize the job state and allocated nodes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -223,7 +223,7 @@ class App < Sinatra::Base
     property :type, type: :string, enum: ['nodes']
     property :attributes do
       property :name, type: :string
-      property :allocated, type: :boolean, description: 'Is true if and only if there is an allocated-job'
+      property :state, type: :string, enum: ::Node::STATES
     end
     property :relationships do
       property :'allocated-job' do

--- a/app.rb
+++ b/app.rb
@@ -44,32 +44,19 @@ class App < Sinatra::Base
   resource :partitions do
     swagger_schema :Partition do
       key :required, :id
-      property :id do
-        key :type, :integer
-      end
-      property :type do
-        key :type, :string
-        key :value, 'partitions'
-      end
+      property :id, type: :string
+      property :type, type: :string, enum: ['partitions']
       property :attributes do
-        property :name do
-          key :type, :string
-        end
-        property :nodes do
-          key :type, :array
+        property :name, type: :string
+        property :nodes, type: :array do
           items { key :type, :string }
         end
       end
     end
 
     swagger_schema :rioPartition do
-      property :type do
-        key :type, :string
-        key :value, :partitions
-      end
-      property :id do
-        key :type, :string
-      end
+      property :type, type: :string, enum: ['partitions']
+      property :id, type: :string
     end
 
     swagger_path '/partitions' do
@@ -79,10 +66,8 @@ class App < Sinatra::Base
         key :operaionId, :indexPartitions
         response 200 do
           schema do
-            property :data do
-              items do
-                key :'$ref', :Partition
-              end
+            property :data, type: :array do
+              items { key :'$ref', :Partition }
             end
           end
         end

--- a/app.rb
+++ b/app.rb
@@ -87,12 +87,15 @@ class App < Sinatra::Base
         property :min_nodes, type: :integer, minimum: 1
         property :script, type: :string
         property :state, type: :string, enum: Job::STATES
+        property 'allocated-nodes' do
+          property :data, type: :array do
+            items type: :string
+          end
+        end
       end
       property :relationships do
         property :partition do
-          property :data do
-            key :'$ref', :rioPartition
-          end
+          property(:data) { key '$ref', :rioPartition }
         end
       end
     end

--- a/app.rb
+++ b/app.rb
@@ -96,22 +96,12 @@ class App < Sinatra::Base
 
   resource :jobs, pkre: /[\w-]+/ do
     swagger_schema :Job do
-      property :type do
-        key :type, :string
-        key :value, 'jobs'
-      end
-      property :id do
-        key :type, :string
-      end
+      property :type, type: :string, enum: ['jobs']
+      property :id, type: :string
       property :attributes do
-        property :min_nodes do
-          key :type, :integer
-          key :default, 1
-          key :minimum, 1
-        end
-        property :script do
-          key :type, :string
-        end
+        property :min_nodes, type: :integer, minimum: 1
+        property :script, type: :string
+        property :state, type: :string, enum: Job::STATES
       end
       property :relationships do
         property :partition do
@@ -123,10 +113,7 @@ class App < Sinatra::Base
     end
 
     swagger_schema :newJob do
-      property :type do
-        key :type, :string
-        key :value, 'jobs'
-      end
+      property :type, type: :string, enum: ['jobs']
       property :attributes do
         key :required, [:'min-nodes', :script, :arguments]
         property :'min-nodes' do
@@ -139,14 +126,9 @@ class App < Sinatra::Base
             key :minimum, 1
           end
         end
-        property :script do
-          key :type, :string
-        end
-        property :arguments do
-          key :type, :array
-          items do
-            key :type, :string
-          end
+        property :script, type: :string
+        property :arguments, type: :array do
+          items type: :string
         end
       end
     end
@@ -157,7 +139,7 @@ class App < Sinatra::Base
         key :operationId, :indexJobs
         response 200 do
           schema do
-            property :data do
+            property :data, type: :array do
               items do
                 key :'$ref', :Job
               end

--- a/app.rb
+++ b/app.rb
@@ -87,11 +87,7 @@ class App < Sinatra::Base
         property :min_nodes, type: :integer, minimum: 1
         property :script, type: :string
         property :state, type: :string, enum: Job::STATES
-        property 'allocated-nodes' do
-          property :data, type: :array do
-            items type: :string
-          end
-        end
+        property('allocated-nodes', type: :array) { items type: :string }
       end
       property :relationships do
         property :partition do

--- a/app.rb
+++ b/app.rb
@@ -52,6 +52,13 @@ class App < Sinatra::Base
           items { key :type, :string }
         end
       end
+      property :relationships do
+        property :'nodes' do
+          property(:data, type: :array) do
+            items { key '$ref', :rioNode }
+          end
+        end
+      end
     end
 
     swagger_schema :rioPartition do
@@ -93,7 +100,17 @@ class App < Sinatra::Base
         property :partition do
           property(:data) { key '$ref', :rioPartition }
         end
+        property :'allocated-nodes' do
+          property(:data, type: :array) do
+            items { key '$ref', :rioNode }
+          end
+        end
       end
+    end
+
+    swagger_schema :rioJob do
+      property :type, type: :string, enum: ['jobs']
+      property :id, type: :string
     end
 
     swagger_schema :newJob do
@@ -198,5 +215,25 @@ class App < Sinatra::Base
     destroy do
       FlightScheduler.app.event_processor.cancel_job(resource)
     end
+  end
+
+  swagger_schema :Node do
+    key :required, :id
+    property :id, type: :string
+    property :type, type: :string, enum: ['nodes']
+    property :attributes do
+      property :name, type: :string
+      property :allocated, type: :boolean, description: 'Is true if and only if there is an allocated-job'
+    end
+    property :relationships do
+      property :'allocated-job' do
+        property(:data) { key '$ref', :rioJob }
+      end
+    end
+  end
+
+  swagger_schema :rioNode do
+    property :type, type: :string, enum: ['nodes']
+    property :id, type: :string
   end
 end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -28,8 +28,14 @@
 class Node
   attr_reader :name
 
+  STATES = ['IDLE', 'ALLOC']
+
   def initialize(name:)
     @name = name
+  end
+
+  def state
+    allocation ? 'ALLOC' : 'IDLE'
   end
 
   def allocation

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -44,7 +44,7 @@ class NodeSerializer < BaseSerializer
   end
 
   attribute :name
-  attribute(:allocated) { !!object.allocation }
+  attribute :state
 
   has_one(:allocated_job) { object.allocation }
   # TODO: Implement the partition link

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -34,16 +34,28 @@ class PartitionSerializer < BaseSerializer
     object.name
   end
   attribute :name
-  attribute :nodes do
-    object.nodes.map(&:name)
+
+  has_many(:nodes) { object.nodes }
+end
+
+class NodeSerializer < BaseSerializer
+  def id
+    object.name
   end
+
+  attribute :name
+  attribute(:allocated) { !!object.allocation }
+
+  has_one(:allocated_job) { object.allocation }
+  # TODO: Implement the partition link
+  # has_one :partition
 end
 
 class JobSerializer < BaseSerializer
   attribute :min_nodes
   attribute :script
   attribute :state
-  attribute(:allocated_nodes) { (object.allocation&.nodes || []).map(&:name) }
 
   has_one :partition
+  has_many(:allocated_nodes) { (object.allocation&.nodes || []) }
 end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -42,6 +42,7 @@ end
 class JobSerializer < BaseSerializer
   attribute :min_nodes
   attribute :script
+  attribute :state
 
   has_one :partition
 end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -43,6 +43,7 @@ class JobSerializer < BaseSerializer
   attribute :min_nodes
   attribute :script
   attribute :state
+  attribute(:allocated_nodes) { (object.allocation&.nodes || []).map(&:name) }
 
   has_one :partition
 end


### PR DESCRIPTION
This PR is reasonable straight forward as it adds the two new fields: `allocated-nodes` and `state`.

The docs have also been refactored a bit so they are more concise. The changes mainly concern updating the syntax. For the most part the semantics are the same, albeit with the additional fields.

EDIT:
There is now a requirement to display the partitions according to the "state". This is a bit tricky as partitions are technically stateless, as it is the `nodes` that is allocated. The `partition` can now be serialised with their `nodes` and thus contain the corresponding `state`. This prevents the duplication of the `Partition` object each time a new "node state" is added. 

Whilst making this change, the `node` can also be serialised against the `job`, which seemed appropriate.