### PR TITLE
Receive and save the script to disk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+script: rspec spec --format documentation --order random
+
+install:
+  - gem install bundler -v 2.1.4
+  - gem update bundler
+  - bundle install
+
+rvm:
+  - 2.5.7
+  - 2.6.4
+  - 2.7.1
+
+branches:
+  only:
+    - master
+    - develop
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
     concurrent-ruby (1.1.7)
     console (1.9.0)
     diff-lcs (1.4.4)
+    fakefs (1.2.2)
     falcon (0.36.5)
       async (~> 1.13)
       async-container (~> 0.16.0)
@@ -85,6 +86,8 @@ GEM
     rack (2.2.3)
     rack-protection (2.1.0)
       rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -134,10 +137,12 @@ DEPENDENCIES
   activemodel
   async-websocket
   concurrent-ruby
+  fakefs
   falcon
   hashie
   pry
   pry-byebug
+  rack-test
   rspec
   sinatra
   sinatra-cors

--- a/app.rb
+++ b/app.rb
@@ -98,8 +98,9 @@ class App < Sinatra::Base
       property :type, type: :string, enum: ['jobs']
       property :id, type: :string
       property :attributes do
-        property :min_nodes, type: :integer, minimum: 1
+        property 'min-nodes', type: :integer, minimum: 1
         property :state, type: :string, enum: Job::STATES
+        property 'script-name', type: :string
       end
       property :relationships do
         property :partition do
@@ -121,7 +122,7 @@ class App < Sinatra::Base
     swagger_schema :newJob do
       property :type, type: :string, enum: ['jobs']
       property :attributes do
-        key :required, [:'min-nodes', :script, :arguments]
+        key :required, [:'min-nodes', :script, 'script-name', :arguments]
         property :'min-nodes' do
           one_of do
             key :type, :string
@@ -133,6 +134,7 @@ class App < Sinatra::Base
           end
         end
         property :script, type: :string
+        property 'script-name',  type: :string
         property :arguments, type: :array do
           items type: :string
         end
@@ -217,6 +219,7 @@ class App < Sinatra::Base
         partition: FlightScheduler.app.default_partition,
         arguments: attr[:arguments],
         script_provided: @script ? true : false,
+        script_name: attr[:script_name],
         state: 'PENDING',
       )
       next job.id, job

--- a/app.rb
+++ b/app.rb
@@ -206,7 +206,7 @@ class App < Sinatra::Base
         id: SecureRandom.uuid,
         min_nodes: attr[:min_nodes],
         partition: FlightScheduler.app.default_partition,
-        script: attr[:script],
+        read_script: attr[:script],
         arguments: attr[:arguments],
         state: 'PENDING',
       )

--- a/app.rb
+++ b/app.rb
@@ -189,6 +189,7 @@ class App < Sinatra::Base
 
       def validate!
         if @created && resource.validate!
+          resource.write_script(@script)
           FlightScheduler.app.event_processor.batch_job_created(resource)
         else
           # TODO: Raise some form of error instead of noop
@@ -202,11 +203,11 @@ class App < Sinatra::Base
 
     create do |attr|
       @created = true
+      @script = attr[:script]
       job = Job.new(
         id: SecureRandom.uuid,
         min_nodes: attr[:min_nodes],
         partition: FlightScheduler.app.default_partition,
-        read_script: attr[:script],
         arguments: attr[:arguments],
         state: 'PENDING',
       )

--- a/app.rb
+++ b/app.rb
@@ -41,6 +41,13 @@ class App < Sinatra::Base
   register Sinja
   self.prepend SinjaContentPatch
 
+  configure_jsonapi do |c|
+    c.validation_exceptions << ActiveModel::ValidationError
+    c.validation_formatter = ->(e) do
+      e.model.errors.messages
+    end
+  end
+
   resource :partitions do
     swagger_schema :Partition do
       key :required, :id
@@ -209,6 +216,7 @@ class App < Sinatra::Base
         min_nodes: attr[:min_nodes],
         partition: FlightScheduler.app.default_partition,
         arguments: attr[:arguments],
+        script_provided: @script ? true : false,
         state: 'PENDING',
       )
       next job.id, job

--- a/app.rb
+++ b/app.rb
@@ -188,8 +188,10 @@ class App < Sinatra::Base
       end
 
       def validate!
-        if resource.validate!
+        if @created && resource.validate!
           FlightScheduler.app.event_processor.batch_job_created(resource)
+        else
+          # TODO: Raise some form of error instead of noop
         end
       end
     end
@@ -199,6 +201,7 @@ class App < Sinatra::Base
     end
 
     create do |attr|
+      @created = true
       job = Job.new(
         id: SecureRandom.uuid,
         min_nodes: attr[:min_nodes],

--- a/app.rb
+++ b/app.rb
@@ -92,9 +92,7 @@ class App < Sinatra::Base
       property :id, type: :string
       property :attributes do
         property :min_nodes, type: :integer, minimum: 1
-        property :script, type: :string
         property :state, type: :string, enum: Job::STATES
-        property('allocated-nodes', type: :array) { items type: :string }
       end
       property :relationships do
         property :partition do

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -41,7 +41,6 @@ class Job
   attr_writer :arguments
   attr_accessor :id
   attr_accessor :partition
-  attr_accessor :read_script
   attr_accessor :state
 
   # Handle the k and m suffix
@@ -68,6 +67,15 @@ class Job
   validates :state,
     presence: true,
     inclusion: { within: STATES }
+
+  def write_script(content)
+    FileUtils.mkdir_p File.dirname(script_path)
+    File.write script_path, content
+  end
+
+  def read_script
+    File.read script_path
+  end
 
   def script_path
     File.join(self.class.job_dir, id, 'job-script')

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -68,6 +68,11 @@ class Job
     presence: true,
     inclusion: { within: STATES }
 
+  # Must be called at the end of the job lifecycle to remove the script
+  def cleanup
+    FileUtils.rm_rf File.dirname(script_path)
+  end
+
   def write_script(content)
     FileUtils.mkdir_p File.dirname(script_path)
     File.write script_path, content
@@ -78,7 +83,7 @@ class Job
   end
 
   def script_path
-    File.join(self.class.job_dir, id, 'job-script')
+    File.join(self.class.job_dir, id.to_s, 'job-script')
   end
 
   def allocation

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -42,6 +42,7 @@ class Job
   attr_accessor :id
   attr_accessor :partition
   attr_accessor :state
+  attr_accessor :script_provided
 
   # Handle the k and m suffix
   attr_reader :min_nodes
@@ -60,6 +61,7 @@ class Job
     end
   end
 
+  validates :script_provided, inclusion: { in: [true] }
   validates :id, presence: true
   validates :min_nodes,
     presence: true,

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -42,6 +42,7 @@ class Job
   attr_accessor :id
   attr_accessor :partition
   attr_accessor :state
+  attr_accessor :script_name
   attr_accessor :script_provided
 
   # Handle the k and m suffix
@@ -61,6 +62,7 @@ class Job
     end
   end
 
+  validates :script_name, presence: true
   validates :script_provided, inclusion: { in: [true] }
   validates :id, presence: true
   validates :min_nodes,

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -29,6 +29,10 @@ require 'active_model'
 class Job
   include ActiveModel::Model
 
+  class << self
+    attr_reader :job_dir
+  end
+
   STATES = %w( PENDING RUNNING CANCELLED COMPLETED FAILED )
   STATES.each do |s|
     define_method("#{s.downcase}?") { self.state == s }
@@ -65,6 +69,10 @@ class Job
   validates :state,
     presence: true,
     inclusion: { within: STATES }
+
+  def script_path
+    File.join(self.class.job_dir, id, 'job-script')
+  end
 
   def allocation
     FlightScheduler.app.allocations.for_job(self.id)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -41,7 +41,7 @@ class Job
   attr_writer :arguments
   attr_accessor :id
   attr_accessor :partition
-  attr_accessor :script
+  attr_accessor :read_script
   attr_accessor :state
 
   # Handle the k and m suffix
@@ -65,7 +65,6 @@ class Job
   validates :min_nodes,
     presence: true,
     numericality: { allow_blank: false, only_integer: true, greater_than_or_equal_to: 1 }
-  validates :script, presence: true
   validates :state,
     presence: true,
     inclusion: { within: STATES }

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -53,7 +53,6 @@ end
 
 class JobSerializer < BaseSerializer
   attribute :min_nodes
-  attribute :script
   attribute :state
 
   has_one :partition

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -54,6 +54,7 @@ end
 class JobSerializer < BaseSerializer
   attribute :min_nodes
   attribute :state
+  attribute :script_name
 
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -45,5 +45,10 @@ require 'patches/sinja_request_body_detection'
 
 require_relative '../app/models/allocation'
 require_relative '../app/models/job'
+
+# Sets the base path to where job details are stored
+dir = ENV.fetch('FLIGHT_SCHEDULER_JOB_DIR', File.expand_path('../var/jobs', __dir__))
+Job.instance_variable_set(:@job_dir, dir)
+
 require_relative '../app/models/node'
 require_relative '../app/models/partition'

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -123,7 +123,7 @@ module FlightScheduler::EventProcessor
             processor.connection.write({
               command: 'JOB_ALLOCATED',
               job_id: job.id,
-              script: job.script,
+              script: job.read_script,
               arguments: job.arguments,
               # TODO: Properly support multiple nodes to a job here
               environment: {

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -50,7 +50,6 @@ module FlightScheduler::EventProcessor
     Async.logger.info("Canceling job #{job.id}")
     return unless %w(PENDING RUNNING).include?(job.state)
 
-    # NOTE: Is the above and below state lines correct? Needs review
     job.state == 'CANCELLED'
     return if job.state == 'PENDING'
 

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -50,6 +50,7 @@ module FlightScheduler::EventProcessor
     Async.logger.info("Canceling job #{job.id}")
     return unless %w(PENDING RUNNING).include?(job.state)
 
+    # NOTE: Is the above and below state lines correct? Needs review
     job.state == 'CANCELLED'
     return if job.state == 'PENDING'
 

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -42,8 +42,13 @@ class FifoScheduler
   end
 
   # Remove a single job from the queue.
+  # TODO: Having 'job.cleanup' is less than ideal, however it is the only place
+  # that is guaranteed to be called regardless what happens to the job
+  # e.g. Cancelled, fails, exits normally
+  # consider refactoring
   def remove_job(job)
     @queue.delete(job)
+    job.cleanup
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
   end
 

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe '/jobs' do
             type: 'jobs',
             attributes: {
               min_nodes: 1,
-              arguments: []
+              arguments: [],
+              script_name: 'something.sh'
             }
           }
         }
@@ -79,7 +80,8 @@ RSpec.describe '/jobs' do
             attributes: {
               min_nodes: 1,
               arguments: [],
-              script: script
+              script: script,
+              script_name: 'something.sh'
             }
           }
         }
@@ -90,7 +92,7 @@ RSpec.describe '/jobs' do
       before(:each) do
         post '/jobs', payload.to_json
 
-        @response_id = JSON.parse(last_response.body).fetch('data', {}).fetch('id')
+        @response_id = JSON.parse(last_response.body).fetch('data', {}).fetch('id', nil)
         @response_job = FlightScheduler.app.scheduler.queue.find { |j| j.id == response_id }
       end
 

--- a/spec/models/allocation_registry_spec.rb
+++ b/spec/models/allocation_registry_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe FlightScheduler::AllocationRegistry, type: :model do
     Job.new(
       id: job_id,
       min_nodes: min_nodes,
-      script: '/some/path',
       arguments: [],
       partition: partition,
     )

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Job, type: :model do
     subject do
       described_class.new(id: SecureRandom.uuid,
                           state: 'PENDING',
+                          script_name: 'something.sh',
                           script_provided: true,
                           min_nodes: input_min_nodes)
     end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Job, type: :model do
     subject do
       described_class.new(id: SecureRandom.uuid,
                           state: 'PENDING',
+                          script_provided: true,
                           min_nodes: input_min_nodes)
     end
 

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Job, type: :model do
 
     subject do
       described_class.new(id: SecureRandom.uuid,
-                          script: '/bin/foo',
                           state: 'PENDING',
                           min_nodes: input_min_nodes)
     end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -28,11 +28,11 @@ require 'spec_helper'
 
 RSpec.describe Node, type: :model do
   subject { Node.new(name: 'node01') }
+
   let(:job) {
     Job.new(
       id: 1,
       min_nodes: 1,
-      script: '/some/path',
       arguments: [],
     )
   }

--- a/spec/models/partition_spec.rb
+++ b/spec/models/partition_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Partition, type: :model do
     Job.new(
       id: 1,
       min_nodes: '2',
-      script: '/some/path',
       arguments: [],
     )
   }

--- a/spec/models/partition_spec.rb
+++ b/spec/models/partition_spec.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
 require 'spec_helper'
 
 RSpec.describe Partition, type: :model do

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Partition, type: :scheduler do
       Job.new(
         id: job_id,
         min_nodes: min_nodes,
-        script: '/some/path',
         state: 'PENDING',
         arguments: [],
         partition: partition,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,32 @@
 # https://github.com/openflighthpc/flight-action-api
 #===============================================================================
 
+require 'bundler'
+Bundler.require(:default, :test)
+
 require_relative '../config/boot'
+
+require 'fakefs/safe'
+require 'rack/test'
+
+require_relative '../app.rb'
+require_relative '../app/websocket_app'
+
+module SpecApp
+  def self.included(base)
+    base.include Rack::Test::Methods
+    base.instance_exec do
+      before(:each) { header 'Content-Type', 'application/vnd.api+json' }
+    end
+  end
+
+  def app
+    @app ||= Rack::Builder.app do
+      map('/ws') { run ::WebsocketApp }
+      map('/') { run ::App }
+    end
+  end
+end
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
Previously only the filepath to the script was sent to the server, as it is assumed all the nodes share a filesystem. This assumption maybe invalid and has been removed.

Instead the script must be sent with the job when it is created. It is than saved to disk so it can be retrieved latter. This required various changes to the internals to remove the old `script` method and replace it with `read_script`. The over-arching design principle is the `script` should not be cached on a `Job` object as it will remain in ram. Instead it has been written to disk asap and the read from disk when required.

The work flow for when the script is deleted could be improved. ATM it is deleted by scheduler

Finally because we are working with files, it is handy to fake the filesystem to prevent the excessive build up of files. This needs to be activated manually to prevent any surprises.

PS Validation errors now return 422 instead of 500