### PR TITLE
Add support for array jobs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -216,15 +216,18 @@ class App < Sinatra::Base
       @created = true
       @script = attr[:script]
       job = Job.new(
+        arguments: attr[:arguments],
+        array: attr[:array],
         id: SecureRandom.uuid,
+        job_type: attr[:array].present? ? 'ARRAY_JOB' : 'JOB',
         min_nodes: attr[:min_nodes],
         partition: FlightScheduler.app.default_partition,
-        arguments: attr[:arguments],
         script_provided: @script ? true : false,
         script_name: attr[:script_name],
         state: 'PENDING',
         reason: 'WaitingForScheduling'
       )
+      job.create_array_tasks if job.job_type == 'ARRAY_JOB'
       next job.id, job
     end
 

--- a/app.rb
+++ b/app.rb
@@ -219,7 +219,6 @@ class App < Sinatra::Base
         arguments: attr[:arguments],
         array: attr[:array],
         id: SecureRandom.uuid,
-        job_type: attr[:array].present? ? 'ARRAY_JOB' : 'JOB',
         min_nodes: attr[:min_nodes],
         partition: FlightScheduler.app.default_partition,
         script_provided: @script ? true : false,

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -71,6 +71,11 @@ class Job
 
   attr_reader :min_nodes
 
+  def initialize(params={})
+    super
+    self.job_type ||= @array ? 'ARRAY_JOB' : 'JOB'
+  end
+
   # Handle the k and m suffix
   def min_nodes=(raw)
     str = raw.to_s
@@ -86,12 +91,8 @@ class Job
     end
   end
 
+  # Validations for all job types.
   validates :id, presence: true
-  validates :min_nodes,
-    presence: true,
-    numericality: { allow_blank: false, only_integer: true, greater_than_or_equal_to: 1 }
-  validates :script_name, presence: true
-  validates :script_provided, inclusion: { in: [true] }
   validates :state,
     presence: true,
     inclusion: { within: STATES }
@@ -102,10 +103,19 @@ class Job
     presence: true,
     inclusion: { within: JOB_TYPES }
 
-  # Validations for ARRAY_JOBS
+  # Validations for `JOB`s.
+  validates :min_nodes,
+    presence: true,
+    numericality: { allow_blank: false, only_integer: true, greater_than_or_equal_to: 1 },
+    if: ->() { job_type == 'JOB' }
+  validates :script_name, presence: true, if: ->() { job_type == 'JOB' }
+  validates :script_provided, inclusion: { in: [true] },
+    if: ->() { job_type == 'JOB' }
+
+  # Validations for `ARRAY_JOB`s.
   validate :validate_array_tasks!, if: ->() { job_type == 'ARRAY_JOB' }
 
-  # Validations for ARRAY_TASKS
+  # Validations for `ARRAY_TASK`s
   validates :array_index,
     presence: true,
     numericality: { allow_blank: false, only_integer: true, greater_than_or_equal_to: 0 },
@@ -113,7 +123,7 @@ class Job
   validates :array_job,
     presence: true, if: ->() { job_type == 'ARRAY_TASK' }
 
-  # Validations for non-ARRAY_TASKS
+  # Validations for `JOB`s and `ARRAY_JOB`s.
   validates :array_index,
     absence: true, unless: ->() { job_type == 'ARRAY_TASK' }
   validates :array_job,
@@ -148,12 +158,13 @@ class Job
 
   def create_array_tasks
     self.array_tasks ||= @array.split(',').map do |idx|
-      self.dup.tap do |task|
-        task.array_index = idx
-        task.array_job = self
-        task.id = SecureRandom.uuid
-        task.job_type = 'ARRAY_TASK'
-        task.state = 'PENDING'
+      Job.new(
+        array_index: idx,
+        array_job: self,
+        id: SecureRandom.uuid,
+        job_type: 'ARRAY_TASK',
+        state: 'PENDING',
+      ).tap do |task|
         task.validate!
       end
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -34,7 +34,7 @@ class Job
   end
 
   REASONS = %w( WaitingForScheduling Priority Resources ).freeze
-  STATES = %w( PENDING RUNNING CANCELLED COMPLETED FAILED ).freeze
+  STATES = %w( PENDING RUNNING CANCELLING CANCELLED COMPLETED FAILED ).freeze
   STATES.each do |s|
     define_method("#{s.downcase}?") { self.state == s }
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -33,23 +33,45 @@ class Job
     attr_reader :job_dir
   end
 
-  REASONS = %w( WaitingForScheduling Priority Resources )
-  STATES = %w( PENDING RUNNING CANCELLED COMPLETED FAILED )
+  REASONS = %w( WaitingForScheduling Priority Resources ).freeze
+  STATES = %w( PENDING RUNNING CANCELLED COMPLETED FAILED ).freeze
   STATES.each do |s|
     define_method("#{s.downcase}?") { self.state == s }
   end
+  def completed?
+    job_type == 'ARRAY_JOB' ?
+      array_tasks.all?(&:completed?) :
+      self.state == 'COMPLETED'
+  end
+
+  JOB_TYPES = %w( JOB ARRAY_JOB ARRAY_TASK ).freeze
+
+  # The index of the task inside the array job.  Only present for ARRAY_TASKS.
+  attr_accessor :array_index
+
+  # A reference to the ARRAY_JOB.  Only present for ARRAY_TASKS.
+  attr_accessor :array_job
+
+  # A reference to all of an ARRAY_JOB's ARRAY_TASKS.  Only present for
+  # ARRAY_JOBS.
+  attr_accessor :array_tasks
+
+  attr_accessor :id
+  attr_accessor :job_type
+  attr_accessor :partition
+  attr_accessor :script_name
+  attr_accessor :script_provided
+  attr_accessor :state
 
   attr_writer :reason
   attr_writer :arguments
-  attr_accessor :id
-  attr_accessor :partition
-  attr_accessor :state
-  attr_accessor :script_name
-  attr_accessor :script_provided
 
-  # Handle the k and m suffix
+  # A list of array indexes.  Only present for ARRAY_JOBS.
+  attr_writer :array
+
   attr_reader :min_nodes
 
+  # Handle the k and m suffix
   def min_nodes=(raw)
     str = raw.to_s
     @min_nodes = if /\A\d+k\Z/.match?(str)
@@ -64,17 +86,38 @@ class Job
     end
   end
 
-  validates :script_name, presence: true
-  validates :script_provided, inclusion: { in: [true] }
   validates :id, presence: true
   validates :min_nodes,
     presence: true,
     numericality: { allow_blank: false, only_integer: true, greater_than_or_equal_to: 1 }
+  validates :script_name, presence: true
+  validates :script_provided, inclusion: { in: [true] }
   validates :state,
     presence: true,
     inclusion: { within: STATES }
   validates :reason,
     inclusion: { within: [*REASONS, nil] }
+
+  validates :job_type,
+    presence: true,
+    inclusion: { within: JOB_TYPES }
+
+  # Validations for ARRAY_JOBS
+  validate :validate_array_tasks!, if: ->() { job_type == 'ARRAY_JOB' }
+
+  # Validations for ARRAY_TASKS
+  validates :array_index,
+    presence: true,
+    numericality: { allow_blank: false, only_integer: true, greater_than_or_equal_to: 0 },
+    if: ->() { job_type == 'ARRAY_TASK' }
+  validates :array_job,
+    presence: true, if: ->() { job_type == 'ARRAY_TASK' }
+
+  # Validations for non-ARRAY_TASKS
+  validates :array_index,
+    absence: true, unless: ->() { job_type == 'ARRAY_TASK' }
+  validates :array_job,
+    absence: true, unless: ->() { job_type == 'ARRAY_TASK' }
 
   def reason
     @reason if pending?
@@ -99,7 +142,21 @@ class Job
   end
 
   def allocation
-    FlightScheduler.app.allocations.for_job(self.id)
+    job_id = job_type == 'ARRAY_TASK' ? array_job.id : self.id
+    FlightScheduler.app.allocations.for_job(job_id)
+  end
+
+  def create_array_tasks
+    self.array_tasks ||= @array.split(',').map do |idx|
+      self.dup.tap do |task|
+        task.array_index = idx
+        task.array_job = self
+        task.id = SecureRandom.uuid
+        task.job_type = 'ARRAY_TASK'
+        task.state = 'PENDING'
+        task.validate!
+      end
+    end
   end
 
   def arguments
@@ -108,5 +165,11 @@ class Job
 
   def hash
     [self.class, id].hash
+  end
+
+  def validate_array_tasks!
+    array_tasks.each do |task|
+      task.validate!
+    end
   end
 end

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -119,6 +119,15 @@ class WebsocketApp
       property "#{prefix}JOB_NODELIST", required: :true, type: :string, format: 'csv',
                 description: 'The node names as a comma spearated list'
       property "#{prefix}NODENAME", required: true, type: :string
+
+      # TODO: It might be worth splitting array tasks into a different schema
+      # NOTE: The required: false is a misnomer. These env vars are all or nothing
+      property "#{prefix}ARRAY_JOB_ID", required: false, type: :string
+      property "#{prefix}ARRAY_TASK_ID", required: false, type: :string
+      property "#{prefix}ARRAY_TASK_COUNT", required: false, type: :string
+      property "#{prefix}ARRAY_TASK_MIN", required: false, type: :string
+      property "#{prefix}ARRAY_TASK_MAX", required: false, type: :string
+
       other_desc = 'Additional arbitrary environment variables'
       other_opts = { required: true, type: :string }
       if prefix.empty?

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -71,22 +71,38 @@ class WebsocketApp
   include Swagger::Blocks
 
   swagger_schema :connectWS do
-    property :command, type: :string, required: true, value: 'CONNECTED'
+    property :command, type: :string, required: true, enum: ['CONNECTED']
     property :node, type: :string, required: true
+  end
+
+  swagger_schema :nodeCompleteArrayTaskWS do
+    property :command, type: :string, requird: true, enum: ['NODE_COMPLETED_ARRAY_TASK']
+    property :node, type: :string, required: true
+    property :array_task_id, type: :string, required: true
+    property :array_job_id, type: :string, required: true
+  end
+
+  swagger_schema :nodeFailedArrayTaskWS do
+    property :command, type: :string, requird: true, enum: ['NODE_FAILED_ARRAY_TASK']
+    property :node, type: :string, required: true
+    property :array_task_id, type: :string, required: true
+    property :array_job_id, type: :string, required: true
   end
 
   swagger_schema :nodeCompletedJobWS do
-    property :command, type: :string, required: true, value: 'NODE_COMPLETED_JOB'
+    property :command, type: :string, required: true, enum: ['NODE_COMPLETED_JOB']
     property :node, type: :string, required: true
+    property :job_id, type: :string, required: true
   end
 
   swagger_schema :nodeFailedJobWS do
-    property :command, type: :string, required: true, value: 'NODE_FAILED_JOB'
+    property :command, type: :string, required: true, enum: ['NODE_FAILED_JOB']
     property :node, type: :string, required: true
+    property :job_id, type: :string, required: true
   end
 
   swagger_schema :jobAllocatedWS do
-    property :command, type: :string, required: true, value: 'JOB_ALLOCATED'
+    property :command, type: :string, required: true, enum: ['JOB_ALLOCATED']
     property :job_id, type: :string, required: true
     property :script, type: :string, required: true
     property :arguments, type: :array, required: true do
@@ -126,6 +142,12 @@ class WebsocketApp
       end
       parameter name: :nodeFailedJob, in: :body do
         schema { key :'$ref', :nodeFailedJobWS }
+      end
+      parameter name: :nodeCompleteArrayTask, in: :body do
+        schema { key :'$ref', :nodeCompleteArrayTaskWS }
+      end
+      parameter name: :nodeFailedArrayTask, in: :body do
+        schema { key :'$ref', :nodeFailedArrayTaskWS }
       end
       # NOTE: At time or writing, this response is handled in FlightScheduler::EventProcessor
       # NOTE: Check the response code

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -49,6 +49,16 @@ class MessageProcessor
       job_id = message[:job_id]
       FlightScheduler.app.event_processor.node_failed_job(@node_name, job_id)
 
+    when 'NODE_COMPLETED_ARRAY_TASK'
+      task_id = message[:array_task_id]
+      job_id = message[:array_job_id]
+      FlightScheduler.app.event_processor.node_completed_task(@node_name, task_id, job_id)
+
+    when 'NODE_FAILED_ARRAY_TASK'
+      task_id = message[:array_task_id]
+      job_id = message[:array_job_id]
+      FlightScheduler.app.event_processor.node_failed_task(@node_name, task_id, job_id)
+
     else
       Async.logger.info("Unknown message #{message}")
     end

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -33,6 +33,7 @@ module FlightScheduler
   autoload(:Schedulers, 'flight_scheduler/schedulers')
 
   module Submission
+    autoload(:ArrayTask, 'flight_scheduler/submission/array_task')
     autoload(:BatchJob, 'flight_scheduler/submission/batch_job')
     autoload(:EnvGenerator, 'flight_scheduler/submission/env_generator')
   end

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -33,6 +33,7 @@ module FlightScheduler
   autoload(:Schedulers, 'flight_scheduler/schedulers')
 
   module Cancellation
+    autoload(:ArrayJob, 'flight_scheduler/cancellation/array_job')
     autoload(:BatchJob, 'flight_scheduler/cancellation/batch_job')
   end
 

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -32,6 +32,10 @@ module FlightScheduler
   autoload(:EventProcessor, 'flight_scheduler/event_processor')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
 
+  module Cancellation
+    autoload(:BatchJob, 'flight_scheduler/cancellation/batch_job')
+  end
+
   module Submission
     autoload(:ArrayTask, 'flight_scheduler/submission/array_task')
     autoload(:BatchJob, 'flight_scheduler/submission/batch_job')

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -32,6 +32,11 @@ module FlightScheduler
   autoload(:EventProcessor, 'flight_scheduler/event_processor')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
 
+  module Submission
+    autoload(:BatchJob, 'flight_scheduler/submission/batch_job')
+    autoload(:EnvGenerator, 'flight_scheduler/submission/env_generator')
+  end
+
   def app
     standard_nodes = %w(node01 node02 node03 node04).map { |name| Node.new(name: name) }
     gpu_nodes = %w(gpu01 gpu02).map { |name| Node.new(name: name) }

--- a/lib/flight_scheduler/cancellation/array_job.rb
+++ b/lib/flight_scheduler/cancellation/array_job.rb
@@ -1,0 +1,87 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+module FlightScheduler::Cancellation
+  # Kill all running processses for the given array job.
+  class ArrayJob
+    class UnconnectedDaemon < RuntimeError ; end
+
+    def initialize(job)
+      @job = job
+    end
+
+    def call
+      allocation = FlightScheduler.app.allocations.for_job(@job.id)
+      if allocation.nil?
+        # The allocation has been cleaned up since we checked the status of
+        # the job.  Perhaps the job has just completed.  This is unlikely, but
+        # possible.
+        return
+      end
+
+      running_tasks = @job.array_tasks.select { |task| task.running? }
+      running_tasks.each do |task|
+        begin
+          # XXX We assume here that all tasks are ran on the same node.  This
+          # assumption is replicated in Submission::ArrayTask, but is
+          # obviously not what we want.
+          target_node = allocation.nodes.first
+          connection = daemon_connection_for(target_node)
+          connection.write({
+            command: 'JOB_CANCELLED',
+            job_id: task.id,
+          })
+          connection.flush
+          Async.logger.debug(
+            "Job cancellation for task #{task.array_index} of job #{@job.id} " +
+            "sent to #{target_node.name}"
+          )
+        rescue
+          # We've failed to cancel one of the array tasks!
+          # XXX What to do here?
+          # XXX Something different for UnconnectedDaemon errors?
+
+          Async.logger.warn(
+            "Error cancelling task #{task.array_index} of job #{@job.id}: #{$!.message}"
+          )
+        else
+          task.state = 'CANCELLED'
+        end
+      end
+      @job.state = 'CANCELLED'
+    end
+
+    private
+
+    def daemon_connection_for(node)
+      processor = FlightScheduler.app.daemon_connections[node.name]
+      raise UnconnectedDaemon, node if processor.nil?
+      processor.connection
+    end
+  end
+end
+

--- a/lib/flight_scheduler/cancellation/batch_job.rb
+++ b/lib/flight_scheduler/cancellation/batch_job.rb
@@ -1,0 +1,76 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+module FlightScheduler::Cancellation
+  # Kill all running processses for the given batch job.
+  class BatchJob
+    class UnconnectedDaemon < RuntimeError ; end
+
+    def initialize(job)
+      @job = job
+    end
+
+    def call
+      allocation = FlightScheduler.app.allocations.for_job(@job.id)
+      if allocation.nil?
+        # The allocation has been cleaned up since we checked the status of
+        # the job.  Perhaps the job has just completed.  This is unlikely, but
+        # possible.
+        return
+      end
+
+      # The submission script has only been submitted to the first node of the
+      # allocation.  We make the assumption that killing that one process will
+      # be sufficient to cause all other to be killed.
+      target_node = allocation.nodes.first
+      connection = daemon_connection_for(target_node)
+      connection.write({
+        command: 'JOB_CANCELLED',
+        job_id: job.id,
+      })
+      connection.flush
+      Async.logger.debug("Job cancellation for #{job.id} sent to #{target_node.name}")
+
+    rescue
+      # We've failed to cancel the job!
+      # XXX What to do here?
+      # XXX Something different for UnconnectedDaemon errors?
+
+      Async.logger.warn("Error cancelling job #{@job.id}: #{$!.message}")
+    else
+      @job.state = 'CANCELLED'
+    end
+
+    private
+
+    def daemon_connection_for(node)
+      processor = FlightScheduler.app.daemon_connections[node.name]
+      raise UnconnectedDaemon, node if processor.nil?
+      processor.connection
+    end
+  end
+end

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -77,7 +77,9 @@ class FifoScheduler
     new_allocations = []
     @allocation_mutex.synchronize do
       loop do
-        next_job = @queue.detect { |job| job.allocation.nil? && job.pending? }
+        next_job = @queue.detect do |job|
+          job.allocation.nil? && job.pending? && !job.job_type != 'ARRAY_TASK'
+        end
         break if next_job.nil?
         allocation = allocate_job(next_job)
         if allocation.nil?

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -50,7 +50,7 @@ module FlightScheduler::Submission
           job_id: task.id,
           array_job_id: @job.id,
           array_task_id: task.id,
-          script: @job.script,
+          script: @job.read_script,
           arguments: @job.arguments,
           environment: EnvGenerator.for_array_task(target_node, @job, task),
         })

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -1,0 +1,85 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+module FlightScheduler::Submission
+  class ArrayTask
+    class UnconnectedDaemon < RuntimeError ; end
+
+    def initialize(allocation)
+      @allocation = allocation
+      @job = allocation.job
+    end
+
+    def call
+      begin
+        task = @job.array_tasks.detect { |task| task.pending? }
+        # XXX task not found.
+        @job.state = 'RUNNING' if @job.pending?
+        task.state = 'RUNNING'
+        target_node = @allocation.nodes.first
+        connection = daemon_connection_for(target_node)
+        Async.logger.debug(
+          "Sending array task #{task.array_index} for #{@job.id} to #{target_node.name}"
+        )
+        connection.write({
+          command: 'JOB_ALLOCATED',
+          job_id: task.id,
+          array_job_id: @job.id,
+          array_task_id: task.id,
+          script: @job.script,
+          arguments: @job.arguments,
+          environment: EnvGenerator.for_array_task(target_node, @job, task),
+        })
+        connection.flush
+        Async.logger.debug(
+          "Sent array task #{task.array_index} for #{@job.id} to #{target_node.name}"
+        )
+      rescue
+        # XXX What to do here for UnconnectedDaemon errors?
+        # 1. abort/cancel the job
+        # 2. allow the job to run on fewer nodes than we thought
+        # 3. something else?
+        #
+        # XXX What to do for other errors?
+        # * Cancel the job on any nodes?
+        # * Remove the allocation?
+        # * Remove the job from the scheduler?
+        # * More?
+        Async.logger.warn("Error running array task #{task.array_index} for #{@job.id}: #{$!.message}")
+        task.state = 'FAILED'
+      end
+    end
+
+    private
+
+    def daemon_connection_for(node)
+      processor = FlightScheduler.app.daemon_connections[node.name]
+      raise UnconnectedDaemon, node if processor.nil?
+      processor.connection
+    end
+  end
+end

--- a/lib/flight_scheduler/submission/batch_job.rb
+++ b/lib/flight_scheduler/submission/batch_job.rb
@@ -1,0 +1,75 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+module FlightScheduler::Submission
+  class BatchJob
+    class UnconnectedDaemon < RuntimeError ; end
+
+    def initialize(allocation)
+      @allocation = allocation
+      @job = allocation.job
+    end
+
+    def call
+      @job.state = 'RUNNING'
+      target_node = @allocation.nodes.first
+      connection = daemon_connection_for(target_node)
+      Async.logger.debug("Sending job #{@job.id} to #{target_node.name}")
+      connection.write({
+        command: 'JOB_ALLOCATED',
+        job_id: @job.id,
+        script: @job.read_script,
+        arguments: @job.arguments,
+        environment: EnvGenerator.for_batch(target_node, @job),
+      })
+      connection.flush
+      Async.logger.debug("Sent job #{@job.id} to #{target_node.name}")
+    rescue
+      # XXX What to do here for UnconnectedDaemon errors?
+      # 1. abort/cancel the job
+      # 2. allow the job to run on fewer nodes than we thought
+      # 3. something else?
+      #
+      # XXX What to do for other errors?
+      # * Cancel the job on any nodes?
+      # * Remove the allocation?
+      # * Remove the job from the scheduler?
+      # * More?
+
+      Async.logger.warn("Error running job #{@job.id}: #{$!.message}")
+      @job.state = 'FAILED'
+    end
+
+    private
+
+    def daemon_connection_for(node)
+      processor = FlightScheduler.app.daemon_connections[node.name]
+      raise UnconnectedDaemon, node if processor.nil?
+      processor.connection
+    end
+  end
+end

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -41,6 +41,19 @@ module FlightScheduler::Submission
     end
     module_function :for_batch
 
+    def for_array_task(node, array_job, array_task)
+      base_env = EnvGenerator.for_batch(node, array_job)
+      task_indexes = array_job.array_tasks.map(&:array_index).map(&:to_i)
+      base_env.merge({
+        "#{prefix}ARRAY_JOB_ID"     => array_job.id,
+        "#{prefix}ARRAY_TASK_ID"    => array_task.array_index.to_s,
+        "#{prefix}ARRAY_TASK_COUNT" => task_indexes.length.to_s,
+        "#{prefix}ARRAY_TASK_MAX"   => task_indexes.max.to_s,
+        "#{prefix}ARRAY_TASK_MIN"   => task_indexes.min.to_s,
+      })
+    end
+    module_function :for_array_task
+
     def prefix
       FlightScheduler::EventProcessor.env_var_prefix
     end

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -1,0 +1,49 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+# Generate the environment for running a job
+module FlightScheduler::Submission
+  module EnvGenerator
+    def for_batch(node, job)
+      allocated_node_names = job.allocation.nodes.map(&:name).join(',')
+      {
+        "#{prefix}CLUSTER_NAME"  => FlightScheduler::EventProcessor.cluster_name.to_s,
+        "#{prefix}JOB_ID"        => job.id,
+        "#{prefix}JOB_PARTITION" => job.partition.name,
+        "#{prefix}JOB_NODES"     => job.allocation.nodes.length.to_s, # Must be a string
+        "#{prefix}JOB_NODELIST"  => allocated_node_names,
+        "#{prefix}NODENAME"      => node.name,
+      }
+    end
+    module_function :for_batch
+
+    def prefix
+      FlightScheduler::EventProcessor.env_var_prefix
+    end
+    module_function :prefix
+  end
+end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe Job, type: :model do
       described_class.new(
         array: input_array,
         id: SecureRandom.uuid,
-        job_type: input_array ? 'ARRAY_JOB' : 'JOB',
         min_nodes: 1,
         script_name: 'something.sh',
         script_provided: true,
@@ -146,6 +145,12 @@ RSpec.describe Job, type: :model do
         it 'array tasks reference the array job' do
           subject.each do |task|
             expect(task.array_job).to be job
+          end
+        end
+
+        it 'array tasks are ARRAY_TASKs' do
+          subject.each do |task|
+            expect(task.job_type).to eq 'ARRAY_TASK'
           end
         end
 

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -27,20 +27,20 @@
 require 'spec_helper'
 
 RSpec.describe Job, type: :model do
-  let(:input_min_nodes) { 10 }
-  let(:input_state) { 'RUNNING' }
-
-  subject do
-    described_class.new(id: SecureRandom.uuid,
-                        state: input_state,
-                        script_name: 'something.sh',
-                        script_provided: true,
-                        min_nodes: input_min_nodes)
-  end
-
   describe '#min_nodes' do
     # Ensure the min nodes is overridden
     let(:input_min_nodes) { raise NotImplementedError }
+
+    subject do
+      described_class.new(
+        id: SecureRandom.uuid,
+        job_type: 'JOB',
+        min_nodes: input_min_nodes,
+        script_name: 'something.sh',
+        script_provided: true,
+        state: 'PENDING',
+      )
+    end
 
     context 'when it is an integer string' do
       let(:input_min_nodes) { '10' }
@@ -74,6 +74,17 @@ RSpec.describe Job, type: :model do
   end
 
   describe '#reason' do
+    let(:input_min_nodes) { 10 }
+    let(:input_state) { 'RUNNING' }
+
+    subject do
+      described_class.new(id: SecureRandom.uuid,
+                          state: input_state,
+                          script_name: 'something.sh',
+                          script_provided: true,
+                          min_nodes: input_min_nodes)
+    end
+
     let(:new_reason) { 'Priority' }
 
     Job::STATES.reject { |r| r == 'PENDING' }.each do |state|

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -107,4 +107,70 @@ RSpec.describe Job, type: :model do
       end
     end
   end
+
+  describe 'array jobs' do
+    let(:job) do
+      described_class.new(
+        array: input_array,
+        id: SecureRandom.uuid,
+        job_type: input_array ? 'ARRAY_JOB' : 'JOB',
+        min_nodes: 1,
+        script_name: 'something.sh',
+        script_provided: true,
+        state: 'PENDING',
+      ).tap do |job|
+        job.create_array_tasks if job.job_type == 'ARRAY_JOB'
+      end
+    end
+
+    subject { job }
+
+    context 'when given an array argument' do
+      let(:input_array) { '1,2' }
+
+      before(:each) do
+        expect(job.job_type).to eq 'ARRAY_JOB'
+      end
+
+      describe 'array tasks' do
+        subject { super().array_tasks }
+
+        it 'creates the correct number of tasks' do
+          expect(subject.length).to eq input_array.split(',').length
+        end
+
+        it 'creates tasks with the correct indexes' do
+          expect(subject.map(&:array_index)).to contain_exactly('1', '2')
+        end
+
+        it 'array tasks reference the array job' do
+          subject.each do |task|
+            expect(task.array_job).to be job
+          end
+        end
+
+        it 'creates valid array tasks' do
+          subject.each do |task|
+            expect(task).to be_valid
+          end
+        end
+      end
+    end
+
+    context 'when not given an array' do
+      let(:input_array) { nil }
+
+      specify 'a job is a JOB' do
+        expect(subject.job_type).to eq 'JOB'
+      end
+
+      describe 'array tasks' do
+        subject { super().array_tasks }
+
+        specify 'have not been created' do
+          expect(subject).to be nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the initial support for array jobs.

## Array job model

The `Job` model has gained a `job_type` attribute which has three possible values: `JOB`, `ARRAY_JOB` and `ARRAY_TASK`.

A `JOB` represents a non-array job, its submission script is submitted to a single node allocated to it.  This is intended to be the type for interactive jobs too.

An `ARRAY_JOB` represents exactly that, an array job.  When created, it will have a number of `ARRAY_TASK`s created for it.  The array task is the job which is submitted to the daemon to be ran.  The state of the array task can be tracked separately from the array job.

The scheduler does not concern itself with `ARRAY_TASK`, instead it allocates resources and schedules `JOB`s and `ARRAY_JOB`s.  When an `ARRAY_JOB` is ran its `ARRAY_TASK`s will be submitted to the allocated nodes.

## Refactoring of submission and cancellation code

The code dealing with submission and cancellation of jobs has been refactored.  There is now a class `Submission::BatchJob` which encapsulates submitting a job to a single node.  There is `Submission::ArrayTask` which encapsulates submitting a single array task to a single node.  `Submission::EnvGenerator` has been added which encapsulates generating the environment for batch and array jobs.

Job cancellation has seen some similar refactoring; `Cancellation::BatchJob` and `Cancellation::ArrayJob`.

There is still some duplication in `EventProcessor` and the new classes indicating that our models are not quite correct, but they will be dealt with in due course as the correct abstractions reveal themselves.

## Limitations

* Currently, only a single node allocated to an array job is used to run the array tasks, and the tasks are not ran in parallel.  To fix these, we need some way of tracking how many tasks can be ran on per-node and which node has been allocated to which task.  Our allocation and job models do not currently support.

* `ARRAY_JOB`s are not displayed correctly in the output of `queue`.  They need to be distinguished from non-array jobs in some manner.

* Cancelling array jobs is supported, but cancelling individual array tasks is not.
