### PR TITLE
Implement a reason why a job is pending

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -101,6 +101,8 @@ class App < Sinatra::Base
         property 'min-nodes', type: :integer, minimum: 1
         property :state, type: :string, enum: Job::STATES
         property 'script-name', type: :string
+        property :reason, type: :string, enum: Job::REASONS, nullable: true
+        property('allocated-nodes', type: :array) { items type: :string }
       end
       property :relationships do
         property :partition do
@@ -221,6 +223,7 @@ class App < Sinatra::Base
         script_provided: @script ? true : false,
         script_name: attr[:script_name],
         state: 'PENDING',
+        reason: 'WaitingForScheduling'
       )
       next job.id, job
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -33,11 +33,13 @@ class Job
     attr_reader :job_dir
   end
 
+  REASONS = %w( WaitingForScheduling Priority Resources )
   STATES = %w( PENDING RUNNING CANCELLED COMPLETED FAILED )
   STATES.each do |s|
     define_method("#{s.downcase}?") { self.state == s }
   end
 
+  attr_writer :reason
   attr_writer :arguments
   attr_accessor :id
   attr_accessor :partition
@@ -71,6 +73,12 @@ class Job
   validates :state,
     presence: true,
     inclusion: { within: STATES }
+  validates :reason,
+    inclusion: { within: [*REASONS, nil] }
+
+  def reason
+    @reason if pending?
+  end
 
   # Must be called at the end of the job lifecycle to remove the script
   def cleanup

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -55,6 +55,7 @@ class JobSerializer < BaseSerializer
   attribute :min_nodes
   attribute :state
   attribute :script_name
+  attribute :reason
 
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -68,9 +68,13 @@ class FifoScheduler
         next_job = @queue.detect { |job| job.allocation.nil? && job.pending? }
         break if next_job.nil?
         allocation = allocate_job(next_job)
-        break if allocation.nil?
-        FlightScheduler.app.allocations.add(allocation)
-        new_allocations << allocation
+        if allocation.nil?
+          next_job.reason = 'Resources'
+          break
+        else
+          FlightScheduler.app.allocations.add(allocation)
+          new_allocations << allocation
+        end
       end
     end
     new_allocations

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -38,6 +38,18 @@ class FifoScheduler
   # Add a single job to the queue.
   def add_job(job)
     @queue << job
+    # As this is a FIFO queue, it can be assumed that the job won't start
+    # immediately due to a previous job. Ipso facto the reason should be Priority
+    #
+    # There is a corner case when the previous job has finished, where the next
+    # job's reason should be WaitingForScheduling. However this should only
+    # be for a brief moment before the job is either:
+    # * ran which reverts the reason to blank, or
+    # * the reason is changed to Resources
+    #
+    # This can be mitigated by only setting the Priority reason if the last
+    # job is pending
+    job.reason = 'Priority' if @queue.last&.pending?
     Async.logger.debug("Added job #{job.id} to #{self.class.name}")
   end
 

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -112,12 +112,23 @@ RSpec.describe Partition, type: :scheduler do
 
       it 'does not create allocations for the following jobs' do
         expected_unallocated_jobs = scheduler.queue[2...]
-
         scheduler.allocate_jobs
 
         expected_unallocated_jobs.each do |job|
           expect(allocations.for_job(job.id)).to be_nil
         end
+      end
+
+      it 'sets the first unallocated job reason to Resources' do
+        first_unallocated = scheduler.queue[2]
+        scheduler.allocate_jobs
+        expect(first_unallocated.reason).to eq('Resources')
+      end
+
+      it 'sets the secondary unallocated job reason to Priority' do
+        secondary_unallocated = scheduler.queue[3]
+        scheduler.allocate_jobs
+        expect(secondary_unallocated.reason).to eq('Priority')
       end
     end
 


### PR DESCRIPTION
The `reason` is a modifier to `pending` jobs as opposed to a distinct `state`. It provides additional information why the job has not been started. Currently there are three reasons:

* `WaitingForScheduling`: The initial state all jobs are created with,
* `Resources`: The job can not be ran due to insufficient resources, and
* `Priority`: The job is not being ran because a previous job has greater priority.

As the only scheduler is currently uses a fifo algorithm, older jobs have a greater priority then newer ones. This allows the `reason` to be changed when a job is added to the scheduler. This will not be the case for other algorithms.

A limitation of the current scheduler is it maybe blocked by a `Resources` job due which will never complete. This issue pre-exists this PR but is now particularly apparent.