### PR TITLE
Improve the array task range handling and array concurrency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
     concurrent-ruby (1.1.7)
     console (1.9.0)
     diff-lcs (1.4.4)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
     fakefs (1.2.2)
     falcon (0.36.5)
       async (~> 1.13)
@@ -137,6 +139,7 @@ DEPENDENCIES
   activemodel
   async-websocket
   concurrent-ruby
+  factory_bot
   fakefs
   falcon
   hashie

--- a/app.rb
+++ b/app.rb
@@ -266,6 +266,7 @@ class App < Sinatra::Base
     end
 
     destroy do
+      resource.cleanup
       FlightScheduler.app.event_processor.cancel_job(resource)
     end
   end

--- a/app.rb
+++ b/app.rb
@@ -266,7 +266,6 @@ class App < Sinatra::Base
     end
 
     destroy do
-      resource.cleanup
       FlightScheduler.app.event_processor.cancel_job(resource)
     end
   end

--- a/app.rb
+++ b/app.rb
@@ -224,7 +224,7 @@ class App < Sinatra::Base
         script_name: attr[:script_name],
         state: 'PENDING',
         reason: 'WaitingForScheduling'
-      ).tap(&:array_tasks) # Ensure the array_tasks are created if required
+      )
       next job.id, job
     end
 

--- a/app.rb
+++ b/app.rb
@@ -102,6 +102,9 @@ class App < Sinatra::Base
         property :state, type: :string, enum: Job::STATES
         property 'script-name', type: :string
         property :reason, type: :string, enum: Job::REASONS, nullable: true
+        property 'first-index', type: :integer, nullable: true
+        property 'last-index', type: :integer, nullable: true
+        property 'next-index', type: :integer, nullable: true
       end
       property :relationships do
         property :partition do
@@ -111,9 +114,6 @@ class App < Sinatra::Base
           property(:data, type: :array) do
             items { key '$ref', :rioTask }
           end
-        end
-        property 'aggregate-task' do
-          key '$ref', :rioTask
         end
         property :'allocated-nodes' do
           property(:data, type: :array) do
@@ -157,15 +157,7 @@ class App < Sinatra::Base
       property :attributes do
         property 'min-nodes', type: :integer, minimum: 1
         property :state, type: :string, enum: Job::STATES
-        property :index do
-          one_of do
-            key :type, :string
-            key :pattern, '^\d+-\d+$'
-          end
-          one_of do
-            key :type, :integer
-          end
-        end
+        property :index, type: :integer
       end
       property :relationships do
         property :job do

--- a/app.rb
+++ b/app.rb
@@ -112,6 +112,9 @@ class App < Sinatra::Base
             items { key '$ref', :rioTask }
           end
         end
+        property 'aggregate-task' do
+          key '$ref', :rioTask
+        end
         property :'allocated-nodes' do
           property(:data, type: :array) do
             items { key '$ref', :rioNode }
@@ -154,6 +157,15 @@ class App < Sinatra::Base
       property :attributes do
         property 'min-nodes', type: :integer, minimum: 1
         property :state, type: :string, enum: Job::STATES
+        property :index do
+          one_of do
+            key :type, :string
+            key :pattern, '^\d+-\d+$'
+          end
+          one_of do
+            key :type, :integer
+          end
+        end
       end
       property :relationships do
         property :job do

--- a/app.rb
+++ b/app.rb
@@ -102,11 +102,15 @@ class App < Sinatra::Base
         property :state, type: :string, enum: Job::STATES
         property 'script-name', type: :string
         property :reason, type: :string, enum: Job::REASONS, nullable: true
-        property('allocated-nodes', type: :array) { items type: :string }
       end
       property :relationships do
         property :partition do
           property(:data) { key '$ref', :rioPartition }
+        end
+        property :'running-tasks' do
+          property(:data, type: :array) do
+            items { key '$ref', :rioTask }
+          end
         end
         property :'allocated-nodes' do
           property(:data, type: :array) do
@@ -142,6 +146,35 @@ class App < Sinatra::Base
         end
         property :array, type: :string, pattern: FlightScheduler::RangeExpander::DOC_REGEX
       end
+    end
+
+    swagger_schema :Task do
+      property :type, type: :string, enum: ['jobs']
+      property :id, type: :string
+      property :attributes do
+        property 'min-nodes', type: :integer, minimum: 1
+        property :state, type: :string, enum: Job::STATES
+      end
+      property :relationships do
+        property :job do
+          property(:data) { key '$ref', :rioJob }
+        end
+        property :'allocated-nodes' do
+          property(:data, type: :array) do
+            items { key '$ref', :rioNode }
+          end
+        end
+      end
+    end
+
+    swagger_schema :rioTask do
+      property :type, type: :string, enum: ['jobs']
+      property :id, type: :string
+    end
+
+    swagger_schema :rioJobTask do
+      property :type, type: :string, enum: ['jobs', 'tasks']
+      property :id, type: :string
     end
 
     swagger_path '/jobs' do
@@ -242,8 +275,8 @@ class App < Sinatra::Base
       property :state, type: :string, enum: ::Node::STATES
     end
     property :relationships do
-      property :'allocated-job' do
-        property(:data) { key '$ref', :rioJob }
+      property :'allocated' do
+        property(:data) { key '$ref', :rioJobTask }
       end
     end
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -52,6 +52,11 @@ class Job
   # A reference to the ARRAY_JOB.  Only present for ARRAY_TASKS.
   attr_accessor :array_job
 
+  # The node an individual task is ran on. This is not used by the "job" variety of Job
+  # NOTE: Do not expose this publicly! It is solely used by the scheduler to track
+  #       which task is running where
+  attr_accessor :task_node
+
   attr_accessor :id
   attr_accessor :job_type
   attr_accessor :partition

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -170,18 +170,6 @@ class Job
 end
 
 class Task
-  # TODO: Reinstate these validations
-  # Validations for `JOB`s and `ARRAY_JOB`s.
-  # validates :array_index,
-  #   absence: true, unless: ->() { job_type == 'ARRAY_TASK' }
-  # validates :array_job,
-  #   absence: true, unless: ->() { job_type == 'ARRAY_TASK' }
-  # Validations for `ARRAY_TASK`s
-  # validates :array_index,
-  #   presence: true,
-  #   numericality: { allow_blank: false, only_integer: true, greater_than_or_equal_to: 0 },
-  #   if: ->() { job_type == 'ARRAY_TASK' }
-
   def initialize(**opts)
     # TODO: Remove the need for the inner_job
     @inner_job = Job.new(**opts)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -176,7 +176,11 @@ class Job
   end
 
   def script_path
-    File.join(self.class.job_dir, id.to_s, 'job-script')
+    if job_type == 'ARRAY_TASK'
+      array_job.script_path
+    else
+      File.join(self.class.job_dir, id.to_s, 'job-script')
+    end
   end
 
   def allocated?

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -136,10 +136,17 @@ class Job
     @array_range = FlightScheduler::RangeExpander.split(range.to_s)
   end
 
+  def task_registry
+    @task_registry ||= FlightScheduler::TaskRegistry.new(self)
+  end
+
+  # Deprecated: This will eventually be replaced by the registry
   def array_tasks
     if job_type == 'ARRAY_JOB'
       @array_tasks ||= array_range.map do |idx|
         Job.new(
+          min_nodes: 1,
+          partition: self.partition,
           array_index: idx,
           array_job: self,
           id: SecureRandom.uuid,

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -179,9 +179,12 @@ class Job
     File.join(self.class.job_dir, id.to_s, 'job-script')
   end
 
+  def allocated?
+    allocation ? true : false
+  end
+
   def allocation
-    job_id = job_type == 'ARRAY_TASK' ? array_job.id : self.id
-    FlightScheduler.app.allocations.for_job(job_id)
+    FlightScheduler.app.allocations.for_job(self.id)
   end
 
   # NOTE: Is wrapping the arguments in an array required?

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -47,11 +47,6 @@ class Job
   # A reference to the ARRAY_JOB.  Only present for ARRAY_TASKS.
   attr_accessor :array_job
 
-  # The node an individual task is ran on. This is not used by the "job" variety of Job
-  # NOTE: Do not expose this publicly! It is solely used by the scheduler to track
-  #       which task is running where
-  attr_accessor :task_node
-
   attr_accessor :id
   attr_accessor :job_type
   attr_accessor :partition

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -81,6 +81,12 @@ class Job
     super
   end
 
+  # A dummy method that wraps min_nodes until max_nodes is implemented
+  # TODO: Implement me!
+  def max_nodes
+    min_nodes
+  end
+
   # Handle the k and m suffix
   def min_nodes=(raw)
     str = raw.to_s

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -43,9 +43,7 @@ class Job
   def completed?
     if job_type == 'ARRAY_JOB'
       return false unless task_registry.finished?
-      task_registry.past_tasks.reduce(true) do |memo, task|
-        memo && task.complete?
-      end
+      task_registry.past_tasks.all?(&:complete?)
     else
       self.state == 'COMPLETED'
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -39,16 +39,6 @@ class Job
     define_method("#{s.downcase}?") { self.state == s }
   end
 
-  # TODO: Check if the complexity in the complete? method is required
-  def completed?
-    if job_type == 'ARRAY_JOB'
-      return false unless task_registry.finished?
-      task_registry.past_tasks.all?(&:complete?)
-    else
-      self.state == 'COMPLETED'
-    end
-  end
-
   JOB_TYPES = %w( JOB ARRAY_JOB ).freeze
 
   # The index of the task inside the array job.  Only present for ARRAY_TASKS.

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -68,7 +68,7 @@ class JobSerializer < BaseSerializer
 
   attribute(:first_index) { object.array_range.expanded.first if object.job_type == 'ARRAY_JOB' }
   attribute(:last_index) { object.array_range.expanded.last if object.job_type == 'ARRAY_JOB' }
-  attribute(:next_index) { object.task_registry.next_task(false).array_index if object.job_type == 'ARRAY_JOB' }
+  attribute(:next_index) { object.task_registry.next_task(false)&.array_index if object.job_type == 'ARRAY_JOB' }
 
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -60,12 +60,15 @@ class JobSerializer < BaseSerializer
 
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }
+
+  has_one(:aggregate_task) { object.task_registry.aggregate_task }
   has_many(:running_tasks) { object.task_registry.running_tasks }
 end
 
 class TaskSerializer < BaseSerializer
   attribute :state
   attribute :min_nodes
+  attribute(:index) { object.array_index }
 
   has_one :job
   has_many(:allocated_nodes) { object.allocation.nodes }

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -57,7 +57,7 @@ class JobSerializer < BaseSerializer
   # excessive calls whilst serializing the object
   def initialize(model, *_)
     super
-    model.task_registry.pending_task if model.job_type == 'ARRAY_JOB'
+    model.task_registry.next_task if model.job_type == 'ARRAY_JOB'
   end
 
 
@@ -68,7 +68,7 @@ class JobSerializer < BaseSerializer
 
   attribute(:first_index) { object.array_range.expanded.first if object.job_type == 'ARRAY_JOB' }
   attribute(:last_index) { object.array_range.expanded.last if object.job_type == 'ARRAY_JOB' }
-  attribute(:next_index) { object.task_registry.pending_task(false).array_index if object.job_type == 'ARRAY_JOB' }
+  attribute(:next_index) { object.task_registry.next_task(false).array_index if object.job_type == 'ARRAY_JOB' }
 
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -46,7 +46,8 @@ class NodeSerializer < BaseSerializer
   attribute :name
   attribute :state
 
-  has_one(:allocated_job) { object.allocation }
+  # NOTE: This may not be a job ¯\_(ツ)_/¯
+  has_one(:allocated) { object.allocation.job }
   # TODO: Implement the partition link
   # has_one :partition
 end
@@ -59,4 +60,13 @@ class JobSerializer < BaseSerializer
 
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }
+  has_many(:running_tasks) { object.task_registry.running_tasks }
+end
+
+class TaskSerializer < BaseSerializer
+  attribute :state
+  attribute :min_nodes
+
+  has_one :job
+  has_many(:allocated_nodes) { object.allocation.nodes }
 end

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -32,6 +32,7 @@ module FlightScheduler
   autoload(:EventProcessor, 'flight_scheduler/event_processor')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
   autoload(:RangeExpander, 'flight_scheduler/range_expander')
+  autoload(:TaskRegistry, 'flight_scheduler/task_registry')
 
   module Cancellation
     autoload(:ArrayJob, 'flight_scheduler/cancellation/array_job')

--- a/lib/flight_scheduler/cancellation/array_job.rb
+++ b/lib/flight_scheduler/cancellation/array_job.rb
@@ -41,7 +41,7 @@ module FlightScheduler::Cancellation
         return
       end
 
-      running_tasks = @job.array_tasks.select { |task| task.running? }
+      running_tasks = @job.task_registry.running_tasks
       running_tasks.each do |task|
         begin
           # XXX We assume here that all tasks are ran on the same node.  This

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -70,6 +70,7 @@ module FlightScheduler::EventProcessor
 
     end
   ensure
+    job.cleanup
     FlightScheduler.app.scheduler.remove_job(job)
   end
   module_function :cancel_job

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -90,10 +90,14 @@ module FlightScheduler::EventProcessor
     new_allocations.each do |allocation|
       allocated_node_names = allocation.nodes.map(&:name).join(',')
       Async.logger.info("Allocated #{allocated_node_names} to job #{allocation.job.id}")
-      if allocation.job.job_type == 'ARRAY_JOB'
+
+      case allocation.job.job_type
+      when 'ARRAY_TASK'
         FlightScheduler::Submission::ArrayTask.new(allocation).call
-      else
+      when 'JOB'
         FlightScheduler::Submission::BatchJob.new(allocation).call
+      else
+        # The ARRAY_JOB can not be started, this condition should never be reached
       end
     end
   end

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -129,7 +129,8 @@ module FlightScheduler::EventProcessor
     Async.logger.info("Node #{node_name} completed task #{task.array_index} for job #{job_id}")
     task.state = 'COMPLETED'
 
-    # TODO: Check if the Job is complete?
+    # Remove the job from the scheduler if finished
+    FlightScheduler.app.scheduler.remove_job(task.array_job) if task.array_job.task_registry.finished?
 
     # Finalise the task
     FlightScheduler.app.allocations.delete(allocation)
@@ -145,7 +146,8 @@ module FlightScheduler::EventProcessor
     # TODO: Should this check the Job?
     task.state = task.cancelling? ? 'CANCELLED' : 'FAILED'
 
-    # TODO: Check if the Job is done?
+    # Remove the job from the scheduler if finished
+    FlightScheduler.app.scheduler.remove_job(task.array_job) if task.array_job.task_registry.finished?
 
     # Finalise the task
     FlightScheduler.app.allocations.delete(allocation)

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -137,6 +137,7 @@ module FlightScheduler::EventProcessor
 
     # Remove the job from the scheduler if finished
     if task.array_job.task_registry.finished?
+      task.array_job.state = 'COMPLETED'
       FlightScheduler.app.scheduler.remove_job(task.array_job)
       task.array_job.cleanup
     end
@@ -157,6 +158,7 @@ module FlightScheduler::EventProcessor
 
     # Remove the job from the scheduler if finished
     if task.array_job.task_registry.finished?
+      task.array_job.state = task.state
       FlightScheduler.app.scheduler.remove_job(task.array_job)
       task.array_job.cleanup
     end

--- a/lib/flight_scheduler/range_expander.rb
+++ b/lib/flight_scheduler/range_expander.rb
@@ -66,7 +66,8 @@ module FlightScheduler
       @expanded ||= expand.sort
     end
 
-    # TODO: Make this a private method
+    private
+
     def expand
       parts.map do |part|
         if match = part.match(DASH_REGEX)

--- a/lib/flight_scheduler/range_expander.rb
+++ b/lib/flight_scheduler/range_expander.rb
@@ -33,7 +33,7 @@ module FlightScheduler
 
     include Enumerable
     extend Forwardable
-    def_delegator :expand, :each
+    def_delegator :expanded, :each
 
     attr_reader :parts
 
@@ -58,6 +58,15 @@ module FlightScheduler
       end
     end
 
+    def length
+      @length ||= expanded.length
+    end
+
+    def expanded
+      @expanded ||= expand.sort
+    end
+
+    # TODO: Make this a private method
     def expand
       parts.map do |part|
         if match = part.match(DASH_REGEX)

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -96,7 +96,7 @@ class FifoScheduler
         if next_job.nil?
           break
         elsif next_job.job_type == 'ARRAY_JOB'
-          if task = next_job.task_registry.pending_task(false)
+          if task = next_job.task_registry.next_task(false)
             next_task = task
           else
             break

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -83,7 +83,7 @@ class FifoScheduler
           if job.job_type == 'ARRAY_TASK'
             false
           elsif job.job_type == 'ARRAY_JOB'
-            !job.task_registry.limit?
+            !job.task_registry.max_tasks_running?
           elsif job.pending? && job.allocation.nil?
             true
           else

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -81,6 +81,8 @@ class FifoScheduler
         next_job = @queue.detect do |job|
           if job.job_type == 'ARRAY_TASK'
             false
+          elsif job.job_type == 'ARRAY_JOB'
+            !job.task_registry.limit?
           elsif job.pending? && job.allocation.nil?
             true
           else
@@ -92,7 +94,6 @@ class FifoScheduler
         next_task = if next_job.nil?
           break
         elsif next_job.job_type == 'ARRAY_JOB'
-          next if next_job.task_registry.limit?
           if task = next_job.task_registry.pending_task(false)
             task
           else

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -54,13 +54,14 @@ class FifoScheduler
   end
 
   # Remove a single job from the queue.
+  # NOTE: ARRAY_TASKS should skip the cleanup as this is handled by the ARRAY_JOB
   # TODO: Having 'job.cleanup' is less than ideal, however it is the only place
   # that is guaranteed to be called regardless what happens to the job
   # e.g. Cancelled, fails, exits normally
   # consider refactoring
   def remove_job(job)
     @queue.delete(job)
-    job.cleanup
+    job.cleanup unless job.job_type == 'ARRAY_TASK'
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
   end
 

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -99,8 +99,7 @@ class FifoScheduler
           if task = next_job.task_registry.pending_task(false)
             next_task = task
           else
-            remove_job(next_job)
-            next
+            break
           end
         end
 

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -92,17 +92,16 @@ class FifoScheduler
         end
 
         # Handle no more jobs and array jobs
-        next_task = if next_job.nil?
+        next_task = next_job
+        if next_job.nil?
           break
         elsif next_job.job_type == 'ARRAY_JOB'
           if task = next_job.task_registry.pending_task(false)
-            task
+            next_task = task
           else
             remove_job(next_job)
             next
           end
-        else
-          next_job
         end
 
         # Create the allocation

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -54,14 +54,8 @@ class FifoScheduler
   end
 
   # Remove a single job from the queue.
-  # NOTE: ARRAY_TASKS should skip the cleanup as this is handled by the ARRAY_JOB
-  # TODO: Having 'job.cleanup' is less than ideal, however it is the only place
-  # that is guaranteed to be called regardless what happens to the job
-  # e.g. Cancelled, fails, exits normally
-  # consider refactoring
   def remove_job(job)
     @queue.delete(job)
-    job.cleanup unless job.job_type == 'ARRAY_TASK'
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
   end
 

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -37,6 +37,14 @@ module FlightScheduler::Submission
 
     def call
       begin
+        # Updates the state/reason on the job
+        if job.task_registry.pending_task
+          job.state = 'PENDING'
+          job.reason = 'Resources'
+        else
+          job.state = 'RUNNING'
+        end
+
         task.state = 'RUNNING'
         target_node = allocation.nodes.first
         connection = FlightScheduler.app.daemon_connections.connection_for(target_node.name)

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -36,7 +36,7 @@ module FlightScheduler::Submission
     def call
       begin
         # Updates the state/reason on the job
-        if job.task_registry.pending_task
+        if job.task_registry.next_task
           job.state = 'PENDING'
           job.reason = 'Resources'
         else

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -27,34 +27,34 @@
 
 module FlightScheduler::Submission
   class ArrayTask
+    attr_reader :allocation, :job, :task
+
     def initialize(allocation)
       @allocation = allocation
-      @job = allocation.job
+      @task = allocation.job
+      @job = task.array_job
     end
 
     def call
       begin
-        task = @job.array_tasks.detect { |task| task.pending? }
-        # XXX task not found.
-        @job.state = 'RUNNING' if @job.pending?
         task.state = 'RUNNING'
-        target_node = @allocation.nodes.first
+        target_node = allocation.nodes.first
         connection = FlightScheduler.app.daemon_connections.connection_for(target_node.name)
         Async.logger.debug(
-          "Sending array task #{task.array_index} for #{@job.id} to #{target_node.name}"
+          "Sending array task #{task.array_index} for #{job.id} to #{target_node.name}"
         )
         connection.write({
           command: 'JOB_ALLOCATED',
           job_id: task.id,
-          array_job_id: @job.id,
+          array_job_id: job.id,
           array_task_id: task.id,
-          script: @job.read_script,
-          arguments: @job.arguments,
-          environment: EnvGenerator.for_array_task(target_node, @job, task),
+          script: job.read_script,
+          arguments: job.arguments,
+          environment: EnvGenerator.for_array_task(target_node, job, task),
         })
         connection.flush
         Async.logger.debug(
-          "Sent array task #{task.array_index} for #{@job.id} to #{target_node.name}"
+          "Sent array task #{task.array_index} for #{job.id} to #{target_node.name}"
         )
       rescue
         # XXX What to do here for UnconnectedNode errors?

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -38,10 +38,10 @@ module FlightScheduler::Submission
         # XXX task not found.
         @job.state = 'RUNNING' if @job.pending?
         task.state = 'RUNNING'
-        target_node = @allocation.nodes.first
-        connection = FlightScheduler.app.daemon_connections.connection_for(target_node.name)
+        task.task_node = @allocation.nodes.first
+        connection = FlightScheduler.app.daemon_connections.connection_for(task.task_node.name)
         Async.logger.debug(
-          "Sending array task #{task.array_index} for #{@job.id} to #{target_node.name}"
+          "Sending array task #{task.array_index} for #{@job.id} to #{task.task_node.name}"
         )
         connection.write({
           command: 'JOB_ALLOCATED',
@@ -50,11 +50,11 @@ module FlightScheduler::Submission
           array_task_id: task.id,
           script: @job.read_script,
           arguments: @job.arguments,
-          environment: EnvGenerator.for_array_task(target_node, @job, task),
+          environment: EnvGenerator.for_array_task(task.task_node, @job, task),
         })
         connection.flush
         Async.logger.debug(
-          "Sent array task #{task.array_index} for #{@job.id} to #{target_node.name}"
+          "Sent array task #{task.array_index} for #{@job.id} to #{task.task_node.name}"
         )
       rescue
         # XXX What to do here for UnconnectedNode errors?

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -27,8 +27,6 @@
 
 module FlightScheduler::Submission
   class ArrayTask
-    attr_reader :allocation, :job, :task
-
     def initialize(allocation)
       @allocation = allocation
       @task = allocation.job
@@ -79,5 +77,9 @@ module FlightScheduler::Submission
         task.state = 'FAILED'
       end
     end
+
+    private
+
+    attr_reader :allocation, :job, :task
   end
 end

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -46,13 +46,12 @@ module FlightScheduler::Submission
         task.allocation.nodes.map(&:name)
       end.flatten
       base_env = EnvGenerator.for_batch(node, array_task, allocated_nodes: nodes)
-      task_indexes = array_job.array_tasks.map(&:array_index).map(&:to_i)
       base_env.merge({
         "#{prefix}ARRAY_JOB_ID"     => array_job.id,
         "#{prefix}ARRAY_TASK_ID"    => array_task.array_index.to_s,
-        "#{prefix}ARRAY_TASK_COUNT" => task_indexes.length.to_s,
-        "#{prefix}ARRAY_TASK_MAX"   => task_indexes.max.to_s,
-        "#{prefix}ARRAY_TASK_MIN"   => task_indexes.min.to_s,
+        "#{prefix}ARRAY_TASK_COUNT" => array_job.array_range.length.to_s,
+        "#{prefix}ARRAY_TASK_MAX"   => array_job.array_range.expanded.first.to_s,
+        "#{prefix}ARRAY_TASK_MIN"   => array_job.array_range.expanded.last.to_s
       })
     end
     module_function :for_array_task

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -75,9 +75,11 @@ class FlightScheduler::TaskRegistry
   def refresh
     @mutex.synchronize do
       # Transition "finalised" tasks from running to past
-      @running_tasks, @past_tasks = @running_tasks.partition do |task|
+      now_running, now_past = @running_tasks.partition do |task|
         task.running? || (task.allocated? && task.pending?)
       end
+      @past_tasks = [*@past_tasks, *now_past]
+      @running_tasks = now_running
 
       # End the update if there are no more tasks
       return if @next_task.nil?

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -32,6 +32,7 @@ class FlightScheduler::TaskRegistry
     @job = job
     @pending_task = task_enum.next
     @running_tasks = []
+    @past_tasks = []
   end
 
   def pending_task
@@ -45,7 +46,8 @@ class FlightScheduler::TaskRegistry
   end
 
   def past_tasks
-    []
+    refresh
+    @past_tasks
   end
 
   private
@@ -54,6 +56,8 @@ class FlightScheduler::TaskRegistry
     unless @pending_task.pending?
       if @pending_task.running?
         @running_tasks << @pending_task
+      else
+        @past_tasks << @pending_task
       end
       @pending_task = task_enum.next
     end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -94,10 +94,19 @@ class FlightScheduler::TaskRegistry
     end
   end
 
-  # TODO: Eventually make the tasks here not in the Job object
   def task_enum
     @task_enum ||= Enumerator.new do |yielder|
-      job.array_tasks.each { |t| yielder << t }
+      job.array_range.each do |idx|
+        yielder << Job.new(
+          min_nodes: 1,
+          partition: job.partition,
+          array_index: idx,
+          array_job: job,
+          id: SecureRandom.uuid,
+          job_type: 'ARRAY_TASK',
+          state: 'PENDING'
+        )
+      end
     end
   end
 end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -30,6 +30,8 @@ class FlightScheduler::TaskRegistry
 
   def initialize(job)
     @job = job
+    @pending_task = task_enum.next
+    @running_tasks = []
   end
 
   def pending_task
@@ -38,12 +40,21 @@ class FlightScheduler::TaskRegistry
   end
 
   def running_tasks
+    refresh
+    @running_tasks
+  end
+
+  def past_tasks
+    []
   end
 
   private
 
   def refresh
-    unless @pending_task&.pending?
+    unless @pending_task.pending?
+      if @pending_task.running?
+        @running_tasks << @pending_task
+      end
       @pending_task = task_enum.next
     end
   end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -97,13 +97,10 @@ class FlightScheduler::TaskRegistry
   def task_enum
     @task_enum ||= Enumerator.new do |yielder|
       job.array_range.each do |idx|
-        yielder << Job.new(
-          min_nodes: 1,
-          partition: job.partition,
+        yielder << Task.new(
           array_index: idx,
           array_job: job,
           id: SecureRandom.uuid,
-          job_type: 'ARRAY_TASK',
           state: 'PENDING'
         )
       end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -1,0 +1,58 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+class FlightScheduler::TaskRegistry
+  attr_reader :job
+
+  def initialize(job)
+    @job = job
+  end
+
+  def pending_task
+    refresh
+    @pending_task
+  end
+
+  def running_tasks
+  end
+
+  private
+
+  def refresh
+    unless @pending_task&.pending?
+      @pending_task = task_enum.next
+    end
+  end
+
+  # TODO: Eventually make the tasks here not in the Job object
+  def task_enum
+    @task_enum ||= Enumerator.new do |yielder|
+      job.array_tasks.each { |t| yielder << t }
+    end
+  end
+end
+

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -56,7 +56,7 @@ class FlightScheduler::TaskRegistry
     @past_tasks
   end
 
-  def limit?(update = true)
+  def max_tasks_running?(update = true)
     refresh if update
     @running_tasks.length >= job.min_nodes
   end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -36,6 +36,11 @@ class FlightScheduler::TaskRegistry
     @mutex = Mutex.new
   end
 
+  def all_tasks(update = true)
+    refresh if update
+    [@pending_task, *@running_tasks, *@past_tasks]
+  end
+
   def pending_task(update = true)
     refresh if update
     @pending_task

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -58,7 +58,7 @@ class FlightScheduler::TaskRegistry
 
   def max_tasks_running?(update = true)
     refresh if update
-    @running_tasks.length >= job.min_nodes
+    @running_tasks.length >= job.max_nodes
   end
 
   def finished?(update = true)

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -61,6 +61,15 @@ class FlightScheduler::TaskRegistry
     @running_tasks.length >= job.min_nodes
   end
 
+  def finished?(update = true)
+    refresh if update
+    if @pending_task
+      false
+    else
+      @running_tasks.empty?
+    end
+  end
+
   private
 
   def refresh

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -82,7 +82,9 @@ class FlightScheduler::TaskRegistry
           false
         end
       end
-      if @pending_task && (@pending_task.allocated? || !@pending_task.pending?)
+      if @pending_task.nil?
+        # NOOP - Finished all tasks
+      elsif @pending_task.allocated? || !@pending_task.pending?
         if @pending_task.running? || @pending_task.allocated?
           @running_tasks << @pending_task
         else

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -61,12 +61,12 @@ class FlightScheduler::TaskRegistry
   def refresh
     @mutex.synchronize do
       @running_tasks.select! do |task|
-        task.running?.tap do |bool|
+        (task.running? || task.allocated?).tap do |bool|
           @past_tasks << task unless bool
         end
       end
-      if @pending_task && !@pending_task.pending?
-        if @pending_task.running?
+      if @pending_task && (@pending_task.allocated? || !@pending_task.pending?)
+        if @pending_task.running? || @pending_task.allocated?
           @running_tasks << @pending_task
         else
           @past_tasks << @pending_task

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -88,7 +88,7 @@ class FlightScheduler::TaskRegistry
   def refresh
     @mutex.synchronize do
       @running_tasks.select! do |task|
-        (task.running? || task.allocated?).tap do |bool|
+        (task.running? || (task.allocated? && task.pending?)).tap do |bool|
           @past_tasks << task unless bool
         end
       end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -70,19 +70,6 @@ class FlightScheduler::TaskRegistry
     end
   end
 
-  # Used solely in the serializer
-  def aggregate_task(update = true)
-    refresh if update
-    if @pending_task
-      Task.new(
-        array_index: "#{@pending_task.array_index}-#{job.array_range.expanded.last}",
-        array_job: job,
-        id: SecureRandom.uuid,
-        state: 'PENDING'
-      )
-    end
-  end
-
   private
 
   def refresh

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -75,7 +75,7 @@ class FlightScheduler::TaskRegistry
     refresh if update
     if @pending_task
       Task.new(
-        array_index: "#{@pending_task.array_index}-#{job.array_range.last}",
+        array_index: "#{@pending_task.array_index}-#{job.array_range.expanded.last}",
         array_job: job,
         id: SecureRandom.uuid,
         state: 'PENDING'

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -30,7 +30,7 @@ class FlightScheduler::TaskRegistry
 
   def initialize(job)
     @job = job
-    @pending_task = task_enum.next
+    @next_task = task_enum.next
     @running_tasks = []
     @past_tasks = []
     @mutex = Mutex.new
@@ -38,12 +38,12 @@ class FlightScheduler::TaskRegistry
 
   def all_tasks(update = true)
     refresh if update
-    [@pending_task, *@running_tasks, *@past_tasks]
+    [@next_task, *@running_tasks, *@past_tasks]
   end
 
-  def pending_task(update = true)
+  def next_task(update = true)
     refresh if update
-    @pending_task
+    @next_task
   end
 
   def running_tasks(update = true)
@@ -63,7 +63,7 @@ class FlightScheduler::TaskRegistry
 
   def finished?(update = true)
     refresh if update
-    if @pending_task
+    if @next_task
       false
     else
       @running_tasks.empty?
@@ -82,18 +82,18 @@ class FlightScheduler::TaskRegistry
           false
         end
       end
-      if @pending_task.nil?
+      if @next_task.nil?
         # NOOP - Finished all tasks
-      elsif @pending_task.allocated? || !@pending_task.pending?
-        if @pending_task.running? || @pending_task.allocated?
-          @running_tasks << @pending_task
+      elsif @next_task.allocated? || !@next_task.pending?
+        if @next_task.running? || @next_task.allocated?
+          @running_tasks << @next_task
         else
-          @past_tasks << @pending_task
+          @past_tasks << @next_task
         end
         begin
-          @pending_task = task_enum.next
+          @next_task = task_enum.next
         rescue StopIteration
-          @pending_task = nil
+          @next_task = nil
         end
       end
     end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -70,6 +70,19 @@ class FlightScheduler::TaskRegistry
     end
   end
 
+  # Used solely in the serializer
+  def aggregate_task(update = true)
+    refresh if update
+    if @pending_task
+      Task.new(
+        array_index: "#{@pending_task.array_index}-#{job.array_range.last}",
+        array_job: job,
+        id: SecureRandom.uuid,
+        state: 'PENDING'
+      )
+    end
+  end
+
   private
 
   def refresh

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -50,6 +50,11 @@ class FlightScheduler::TaskRegistry
     @past_tasks
   end
 
+  def limit?
+    refresh
+    @running_tasks.length >= job.min_nodes
+  end
+
   private
 
   def refresh

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -53,6 +53,11 @@ class FlightScheduler::TaskRegistry
   private
 
   def refresh
+    @running_tasks.select! do |task|
+      task.running?.tap do |bool|
+        @past_tasks << task unless bool
+      end
+    end
     unless @pending_task.pending?
       if @pending_task.running?
         @running_tasks << @pending_task

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -75,8 +75,11 @@ class FlightScheduler::TaskRegistry
   def refresh
     @mutex.synchronize do
       @running_tasks.select! do |task|
-        (task.running? || (task.allocated? && task.pending?)).tap do |bool|
-          @past_tasks << task unless bool
+        if task.running? || (task.allocated? && task.pending?)
+          true
+        else
+          @past_tasks << task
+          false
         end
       end
       if @pending_task && (@pending_task.allocated? || !@pending_task.pending?)

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -165,12 +165,6 @@ RSpec.describe '/jobs' do
         expect(response_job).to be_a ::Job
         expect(response_job.job_type).to eq 'ARRAY_JOB'
       end
-
-      it 'creates the correct ARRAY_TASKs' do
-        tasks = response_job.array_tasks
-        expect(tasks.map(&:array_index)).to contain_exactly(2, 4, 6)
-        expect(tasks.map(&:job_type).uniq).to contain_exactly('ARRAY_TASK')
-      end
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #==============================================================================
 # Copyright (C) 2020-present Alces Flight Ltd.
 #
@@ -26,28 +25,19 @@
 # https://github.com/openflighthpc/flight-scheduler-controller
 #==============================================================================
 
-source "https://rubygems.org"
+FactoryBot.define do
+  factory :job do
+    # NOTE: job_type is only pseudo part of the public interface and thus is not
+    #       part of this factory
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
-gem 'activemodel', require: 'active_model'
-gem 'async-websocket'
-gem 'concurrent-ruby', require: 'concurrent'
-gem 'hashie'
-gem 'falcon'
-gem 'sinatra'
-gem 'sinatra-cors'
-gem 'sinja', '>= 1.3.0'
-gem 'swagger-blocks'
-
-group :test do
-  group :development do
-    gem 'pry'
-    gem 'pry-byebug'
+    id { SecureRandom.uuid }
+    partition { FlightScheduler.app.default_partition }
+    min_nodes { 1 }
+    script_provided { true } # NOTE: The factory does not actually create the script
+    script_name { 'demo.sh' }
+    state { 'PENDING' }
+    reason { 'WaitingForScheduling' }
+    arguments { [] }
+    array { nil }
   end
-
-  gem 'rspec'
-  gem 'fakefs', require: 'fakefs/safe'
-  gem 'rack-test'
-  gem 'factory_bot'
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -132,17 +132,17 @@ RSpec.describe Job, type: :model do
       # TODO: This whole section should be merged in with TaskRegistry
       describe 'array tasks' do
         it 'array tasks reference the array job' do
-          task = subject.task_registry.pending_task
+          task = subject.task_registry.next_task
           expect(task.array_job).to be job
         end
 
         it 'array tasks are ARRAY_TASKs' do
-          task = subject.task_registry.pending_task
+          task = subject.task_registry.next_task
           expect(task.job_type).to eq 'ARRAY_TASK'
         end
 
         it 'creates valid array tasks' do
-          task = subject.task_registry.pending_task
+          task = subject.task_registry.next_task
           expect(task).to be_valid
         end
       end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -129,49 +129,21 @@ RSpec.describe Job, type: :model do
         expect(job.job_type).to eq 'ARRAY_JOB'
       end
 
+      # TODO: This whole section should be merged in with TaskRegistry
       describe 'array tasks' do
-        subject { super().array_tasks }
-
-        it 'creates the correct number of tasks' do
-          expect(subject.length).to eq input_array.split(',').length
-        end
-
-        it 'creates tasks with the correct indexes' do
-          expect(subject.map(&:array_index)).to contain_exactly(1, 2)
-        end
-
         it 'array tasks reference the array job' do
-          subject.each do |task|
-            expect(task.array_job).to be job
-          end
+          task = subject.task_registry.pending_task
+          expect(task.array_job).to be job
         end
 
         it 'array tasks are ARRAY_TASKs' do
-          subject.each do |task|
-            expect(task.job_type).to eq 'ARRAY_TASK'
-          end
+          task = subject.task_registry.pending_task
+          expect(task.job_type).to eq 'ARRAY_TASK'
         end
 
         it 'creates valid array tasks' do
-          subject.each do |task|
-            expect(task).to be_valid
-          end
-        end
-      end
-    end
-
-    context 'when not given an array' do
-      let(:input_array) { nil }
-
-      specify 'a job is a JOB' do
-        expect(subject.job_type).to eq 'JOB'
-      end
-
-      describe 'array tasks' do
-        subject { super().array_tasks }
-
-        specify 'have not been created' do
-          expect(subject).to be nil
+          task = subject.task_registry.pending_task
+          expect(task).to be_valid
         end
       end
     end

--- a/spec/range_expander_spec.rb
+++ b/spec/range_expander_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe FlightScheduler::RangeExpander do
   shared_examples 'expands-range' do
     it { should be_valid }
 
-    describe '#expand' do
+    describe '#expanded' do
       it 'expands the parts' do
-        expect(subject.expand).to contain_exactly(*expected)
+        expect(subject.expanded).to contain_exactly(*expected)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -129,4 +129,11 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # Load factory methods
+  config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
 end

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe FlightScheduler::TaskRegistry do
   subject { described_class.new(job) }
 
   context 'with an array job' do
-    let(:job) { build(:job, array: '1-10', min_nodes: 4) }
+    let(:max) { 10 }
+    let(:job) { build(:job, array: "1-#{max}", min_nodes: 4) }
 
     describe '#pending_task' do
       it 'returns the first pending task' do
@@ -46,6 +47,11 @@ RSpec.describe FlightScheduler::TaskRegistry do
         subject.pending_task
         task = subject.pending_task
         expect(task.array_index).to eq(1)
+      end
+
+      it 'returns nil after all tasks have been started' do
+        (max + 2).times { subject.pending_task&.state = 'RUNNING' }
+        expect(subject.pending_task).to be_nil
       end
     end
 

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -55,6 +55,28 @@ RSpec.describe FlightScheduler::TaskRegistry do
       end
     end
 
+    describe '#limit?' do
+      it { should_not be_limit }
+
+      context 'when a job is running on each node' do
+        before do
+          job.min_nodes.times do
+            subject.pending_task.state = 'RUNNING'
+          end
+        end
+
+        it { should be_limit }
+
+        context 'when a job finishes' do
+          before do
+            subject.running_tasks.first.state = 'FINISHED'
+          end
+
+          it { should_not be_limit }
+        end
+      end
+    end
+
     context 'when the pending task transitions to: RUNNING' do
       let(:first) { subject.pending_task }
       before { first.state = 'RUNNING' }

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -1,0 +1,52 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+require 'spec_helper'
+
+RSpec.describe FlightScheduler::TaskRegistry do
+  let(:job) { raise NotImplementedError }
+  subject { described_class.new(job) }
+
+  context 'with an array job' do
+    let(:job) { build(:job, array: '1-10', min_nodes: 4) }
+
+    describe '#pending_task' do
+      it 'returns the first pending task' do
+        task = subject.pending_task
+        expect(task.array_index).to eq(1)
+      end
+
+      it 'does not increment past pending tasks' do
+        subject.pending_task
+        subject.pending_task
+        subject.pending_task
+        task = subject.pending_task
+        expect(task.array_index).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe FlightScheduler::TaskRegistry do
     context 'when a running task transitions to FINISHED' do
       let(:task) { subject.pending_task }
       before do
+        allow(task).to receive(:allocated?).and_return(true)
         task.state = 'RUNNING'
         subject.send(:refresh)
         task.state = 'FINISHED'

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -47,6 +47,29 @@ RSpec.describe FlightScheduler::TaskRegistry do
         task = subject.pending_task
         expect(task.array_index).to eq(1)
       end
+
+      context 'after starting the pending task' do
+        before { subject.pending_task.state = 'RUNNING' }
+
+        it 'moves to the next task' do
+          expect(subject.pending_task.array_index).to eq(2)
+        end
+      end
+    end
+
+    describe '#running_task' do
+      it 'returns empty by default' do
+        expect(subject.running_tasks).to be_empty
+      end
+
+      context 'after starting the pending task' do
+        let(:first_task) { subject.pending_task }
+        before { first_task.state = 'RUNNING' }
+
+        it 'includes the first task' do
+          expect(subject.running_tasks).to contain_exactly(first_task)
+        end
+      end
     end
   end
 end

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -106,6 +106,30 @@ RSpec.describe FlightScheduler::TaskRegistry do
       end
     end
 
+    context 'when the pending task is allocated' do
+      let(:first) { subject.pending_task }
+      before { allow(first).to receive(:allocated?).and_return(true) }
+
+      describe '#pending_task' do
+        it 'moves to the next task' do
+          expect(subject.pending_task.array_index).to eq(2)
+        end
+      end
+
+      describe '#running_tasks' do
+        it 'includes the first task' do
+          subject.pending_task # This test needs a double refresh
+          expect(subject.running_tasks).to contain_exactly(first)
+        end
+      end
+
+      describe '#past_tasks' do
+        it 'does not incude the first task' do
+          expect(subject.past_tasks).to be_empty
+        end
+      end
+    end
+
     (Job::STATES.dup - ['RUNNING', 'PENDING']).each do |state|
       context "when the pending tasks transitions to: #{state}" do
         let(:first) { subject.pending_task }

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -102,5 +102,26 @@ RSpec.describe FlightScheduler::TaskRegistry do
         end
       end
     end
+
+    context 'when a running task transitions to FINISHED' do
+      let(:task) { subject.pending_task }
+      before do
+        task.state = 'RUNNING'
+        subject.send(:refresh)
+        task.state = 'FINISHED'
+      end
+
+      describe '#running_task' do
+        it 'does not contain the task' do
+          expect(subject.running_tasks).to be_empty
+        end
+      end
+
+      describe '#past_tasks' do
+        it 'contains the task' do
+          expect(subject.past_tasks).to contain_exactly(task)
+        end
+      end
+    end
   end
 end

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe FlightScheduler::TaskRegistry do
       end
 
       it 'returns nil after all tasks have been started' do
-        (max + rand(1..10)).times { subject.next_task&.state = 'RUNNING' }
+        max.times { subject.next_task&.state = 'RUNNING' }
         expect(subject.next_task).to be_nil
       end
     end

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -83,6 +83,28 @@ RSpec.describe FlightScheduler::TaskRegistry do
       end
     end
 
+    describe '#finished?' do
+      it { should_not be_finished }
+
+      context 'when all the jobs are RUNNING' do
+        before do
+          max.times { subject.pending_task.state = 'RUNNING' }
+        end
+
+        it { should_not be_finished }
+      end
+
+      (Job::STATES.dup - ['RUNNING', 'PENDING']).each do |state|
+        context "when all the jobs are: #{state}" do
+          before do
+            max.times { subject.pending_task.state = state }
+          end
+
+          it { should be_finished }
+        end
+      end
+    end
+
     context 'when the pending task transitions to: RUNNING' do
       let(:first) { subject.pending_task }
       before { first.state = 'RUNNING' }

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe FlightScheduler::TaskRegistry do
       end
 
       it 'returns nil after all tasks have been started' do
-        (max + 2).times { subject.next_task&.state = 'RUNNING' }
+        (max + rand(1..10)).times { subject.next_task&.state = 'RUNNING' }
         expect(subject.next_task).to be_nil
       end
     end

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -152,6 +152,24 @@ RSpec.describe FlightScheduler::TaskRegistry do
       end
     end
 
+    context 'with existing past task and a running task' do
+      before do
+        @past = subject.next_task
+        @past.state = 'FINISHED'
+        @running = subject.next_task
+        @running.state = 'RUNNING'
+        subject.next_task
+      end
+
+      context 'when transitioning the running task to past' do
+        before { @running.state = 'FINISHED' }
+
+        it 'does not forget the previous running task' do
+          expect(subject.past_tasks.include?(@past)).to be true
+        end
+      end
+    end
+
     (Job::STATES.dup - ['RUNNING', 'PENDING']).each do |state|
       context "when the pending tasks transitions to: #{state}" do
         let(:first) { subject.next_task }

--- a/spec/task_registry_spec.rb
+++ b/spec/task_registry_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe FlightScheduler::TaskRegistry do
       end
     end
 
-    describe '#limit?' do
-      it { should_not be_limit }
+    describe '#max_tasks_running?' do
+      it { should_not be_max_tasks_running }
 
       context 'when a job is running on each node' do
         before do
@@ -71,14 +71,14 @@ RSpec.describe FlightScheduler::TaskRegistry do
           end
         end
 
-        it { should be_limit }
+        it { should be_max_tasks_running }
 
         context 'when a job finishes' do
           before do
             subject.running_tasks.first.state = 'FINISHED'
           end
 
-          it { should_not be_limit }
+          it { should_not be_max_tasks_running }
         end
       end
     end


### PR DESCRIPTION
The range handling has been improved to support `csv` format as well as dash ranges: `1-10` and multiplier ranges: `1-10:3`. The expansion logic has been abstracted into its own class here:
https://github.com/openflighthpc/flight-scheduler-controller/blob/dev/array-ranges/lib/flight_scheduler/range_expander.rb

It also adds the first attempt of concurrency of array tasks. Each "submission" of an "array job" will poll for its available allocated nodes and starts a new task on them. A node is defined as available if it hasn't been assigned to a running Job.

EDIT: The first section of this work has been split out into #13. It will need to be merged first