### PR TITLE
Set various other environment variables within the job

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -38,6 +38,11 @@ class Node
     allocation ? 'ALLOC' : 'IDLE'
   end
 
+  # TODO: Come up with a better way to assign IDs, this should be globally unique
+  def id
+    /\d+/.match(name).first
+  end
+
   def allocation
     FlightScheduler.app.allocations.for_node(self.name)
   end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -40,7 +40,7 @@ class Node
 
   # TODO: Come up with a better way to assign IDs, this should be globally unique
   def id
-    /\d+/.match(name).first
+    /\d+/.match(name)[0]
   end
 
   def allocation

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -185,14 +185,14 @@ class WebsocketApp
     property :username, type: :string, required: true
 
     property :environment, required: true do
-      FlightScheduler::Submission::EnvGenerator::BATCH_ENV_VARS.each do |key, swagger:|
+      FlightScheduler::Submission::EnvGenerator::BATCH_ENV_VARS.each do |key, swagger: {}, **_|
         property FlightScheduler::Submission::EnvGenerator.prefix_key(key),
-                 type: :string, required: true, **(swagger || {})
+                 type: :string, required: true, **swagger
       end
 
-      FlightScheduler::Submission::EnvGenerator::ARRAY_ENV_VARS.each do |key, swagger:|
+      FlightScheduler::Submission::EnvGenerator::ARRAY_ENV_VARS.each do |key, swagger: {}, **_|
         property FlightScheduler::Submission::EnvGenerator.prefix_key(key),
-                 type: :string, required: false, **(swagger || {})
+                 type: :string, required: false, **swagger
       end
 
       prefix = FlightScheduler::Submission::EnvGenerator.prefix_key('')

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -184,28 +184,20 @@ class WebsocketApp
     property :job_id, type: :string, required: true
     property :username, type: :string, required: true
 
-    prefix = FlightScheduler.app.config.env_var_prefix
     property :environment, required: true do
-      property "#{prefix}CLUSTER_NAME", required: true, type: :string,
-               value: FlightScheduler.app.config.cluster_name
-      property "#{prefix}JOB_ID", required: true, type: :string
-      property "#{prefix}JOB_PARTITION", required: true, type: :string
-      property "#{prefix}JOB_NODES", requied: true, type: :string, pattern: '^\d+$',
-                description: 'The total number of nodes assigned to the job'
-      property "#{prefix}JOB_NODELIST", required: :true, type: :string, format: 'csv',
-                description: 'The node names as a comma spearated list'
-      property "#{prefix}NODENAME", required: true, type: :string
+      FlightScheduler::Submission::EnvGenerator::BATCH_ENV_VARS.each do |key, swagger:|
+        property FlightScheduler::Submission::EnvGenerator.prefix_key(key),
+                 type: :string, required: true, **(swagger || {})
+      end
 
-      # TODO: It might be worth splitting array tasks into a different schema
-      # NOTE: The required: false is a misnomer. These env vars are all or nothing
-      property "#{prefix}ARRAY_JOB_ID", required: false, type: :string
-      property "#{prefix}ARRAY_TASK_ID", required: false, type: :string
-      property "#{prefix}ARRAY_TASK_COUNT", required: false, type: :string
-      property "#{prefix}ARRAY_TASK_MIN", required: false, type: :string
-      property "#{prefix}ARRAY_TASK_MAX", required: false, type: :string
+      FlightScheduler::Submission::EnvGenerator::ARRAY_ENV_VARS.each do |key, swagger:|
+        property FlightScheduler::Submission::EnvGenerator.prefix_key(key),
+                 type: :string, required: false, **(swagger || {})
+      end
 
+      prefix = FlightScheduler::Submission::EnvGenerator.prefix_key('')
       other_desc = 'Additional arbitrary environment variables'
-      other_opts = { required: true, type: :string }
+      other_opts = { required: false, type: :string }
       if prefix.empty?
         property '<other>', description: other_desc, **other_opts
       else

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -37,7 +37,9 @@ module FlightScheduler::Submission
       },
       'JOB_ID'        => { block: proc { |_, j| j.id } },
       'JOBID'         => { block: proc { |_, j| j.id } },
-      'JOB_NAME'      => { block: proc { |_, j| j.batch_script&.name } },
+      'JOB_NAME'      => {
+        block: proc { |_, j| (j.job_type == 'ARRAY_TASK' ? j.array_job : j).batch_script&.name }
+      },
       'JOB_PARTITION' => { block: proc { |_, j| j.partition.name } },
       'JOB_NUM_NODES' => {
         swagger: { pattern: '^\d+$', description: 'The total number of nodes assigned to the job' },

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -48,7 +48,12 @@ module FlightScheduler::Submission
         swagger: { format: 'csv', description: 'The node names as a comma spearated list' },
         block: proc { |_, _, a| a.nodes.map(&:name).join(',') }
       },
-      'NODENAME'      => { block: proc { |n| n.name } }
+      'NODENAME'      => { block: proc { |n| n.name } },
+      'CPUS_ON_NODE'  => { block: proc { 1 } },
+      'JOB_CPUS_ON_NODE'  => { block: proc { 1 } },
+      'NTASKS'  => { block: proc { 1 } },
+      'HET_SIZE'  => { block: proc { 1 } },
+      'TASKS_PER_NODE'  => { block: proc { 1 } },
     }
 
     ARRAY_ENV_VARS = {

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -36,6 +36,7 @@ module FlightScheduler::Submission
         block: proc { FlightScheduler.app.config.cluster_name.to_s }
       },
       'JOB_ID'        => { block: proc { |_, j| j.id } },
+      'JOBID'         => { block: proc { |_, j| j.id } },
       'JOB_NAME'      => { block: proc { |_, j| j.batch_script&.name } },
       # TODO: Correctly set the env when --ntasks is implemented
       'JOB_PARTITION' => { block: proc { |_, j| j.partition.name } },
@@ -63,18 +64,19 @@ module FlightScheduler::Submission
       'NODEID'        => { block: proc { |n| n.id } },
 
       # TODO: Build this into the API
-      'SUBMIT_DIR'    => { block: proc { |n| Etc.getpwnam(n.username).dir } },
+      'SUBMIT_DIR'    => { block: proc { |_, j| Etc.getpwnam(j.username).dir } },
 
       # TODO: Determine where the UID/GID should come from
-      'JOB_USER'  => { block: proc { |n| n.username } },
-      'JOB_UID'   => { block: proc { |n| Etc.getpwnam(n.username).uid } },
-      'JOB_GID'   => { block: proc { |n| Etc.getpwnam(n.username).gid } },
+      'JOB_USER'  => { block: proc { |_, j| j.username } },
+      'JOB_UID'   => { block: proc { |_, j| Etc.getpwnam(j.username).uid } },
+      'JOB_GID'   => { block: proc { |_, j| Etc.getpwnam(j.username).gid } },
 
       # TODO: Confirm what the following env vars should be ¯\_(ツ)_/¯
+      'SUBMIT_HOST'       => { block: proc { `hostname --fqdn`.chomp } },
       'NODE_ALIASES'      => { block: proc { '(null)' } },
-      'PRIO_PROCESS'      => { block: proc { 1 } },
+      'PRIO_PROCESS'      => { block: proc { 0 } },
       'CPUS_ON_NODE'      => { block: proc { 1 } },
-      'JOB_CPUS_ON_NODE'  => { block: proc { '1(x2)' } },
+      'JOB_CPUS_PER_NODE'  => { block: proc { '1(x2)' } },
       'TASKS_PER_NODE'    => { block: proc { '1(x2)' } },
       'TOPOLOGY_ADDR'     => { block: proc { |n| n.name } },
       'TOPOLOGY_ADDR_PATTERN'     => { block: proc { |n| n.name.sub(/\[.*\Z/, '') } },

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -38,9 +38,16 @@ module FlightScheduler::Submission
       'JOB_ID'        => { block: proc { |_, j| j.id } },
       'JOB_NAME'      => { block: proc { |_, j| j.batch_script&.name } },
       # TODO: Correctly set the env when --ntasks is implemented
-      'JOB_NTASKS'    => { block: proc { 1 } },
       'JOB_PARTITION' => { block: proc { |_, j| j.partition.name } },
       'JOB_NUM_NODES' => {
+        swagger: { pattern: '^\d+$', description: 'The total number of nodes assigned to the job' },
+        block: proc { |_, _, a| a.nodes.length }
+      },
+      'JOB_NNODES' => {
+        swagger: { pattern: '^\d+$', description: 'The total number of nodes assigned to the job' },
+        block: proc { |_, _, a| a.nodes.length }
+      },
+      'NNODES' => {
         swagger: { pattern: '^\d+$', description: 'The total number of nodes assigned to the job' },
         block: proc { |_, _, a| a.nodes.length }
       },
@@ -48,12 +55,32 @@ module FlightScheduler::Submission
         swagger: { format: 'csv', description: 'The node names as a comma spearated list' },
         block: proc { |_, _, a| a.nodes.map(&:name).join(',') }
       },
+      'NODELIST'  => {
+        swagger: { format: 'csv', description: 'The node names as a comma spearated list' },
+        block: proc { |_, _, a| a.nodes.map(&:name).join(',') }
+      },
       'NODENAME'      => { block: proc { |n| n.name } },
-      'CPUS_ON_NODE'  => { block: proc { 1 } },
-      'JOB_CPUS_ON_NODE'  => { block: proc { 1 } },
-      'NTASKS'  => { block: proc { 1 } },
-      'HET_SIZE'  => { block: proc { 1 } },
-      'TASKS_PER_NODE'  => { block: proc { 1 } },
+      'NODEID'        => { block: proc { |n| n.id } },
+
+      # TODO: Build this into the API
+      'SUBMIT_DIR'    => { block: proc { |n| Etc.getpwnam(n.username).dir } },
+
+      # TODO: Determine where the UID/GID should come from
+      'JOB_USER'  => { block: proc { |n| n.username } },
+      'JOB_UID'   => { block: proc { |n| Etc.getpwnam(n.username).uid } },
+      'JOB_GID'   => { block: proc { |n| Etc.getpwnam(n.username).gid } },
+
+      # TODO: Confirm what the following env vars should be ¯\_(ツ)_/¯
+      'NODE_ALIASES'      => { block: proc { '(null)' } },
+      'PRIO_PROCESS'      => { block: proc { 1 } },
+      'CPUS_ON_NODE'      => { block: proc { 1 } },
+      'JOB_CPUS_ON_NODE'  => { block: proc { '1(x2)' } },
+      'TASKS_PER_NODE'    => { block: proc { '1(x2)' } },
+      'TOPOLOGY_ADDR'     => { block: proc { |n| n.name } },
+      'TOPOLOGY_ADDR_PATTERN'     => { block: proc { |n| n.name.sub(/\[.*\Z/, '') } },
+      'PROCID'            => { block: proc { 0 } },
+      'LOCALID'           => { block: proc { 0 } },
+      'GTIDS'             => { block: proc { 0 } }
     }
 
     ARRAY_ENV_VARS = {

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -38,7 +38,6 @@ module FlightScheduler::Submission
       'JOB_ID'        => { block: proc { |_, j| j.id } },
       'JOBID'         => { block: proc { |_, j| j.id } },
       'JOB_NAME'      => { block: proc { |_, j| j.batch_script&.name } },
-      # TODO: Correctly set the env when --ntasks is implemented
       'JOB_PARTITION' => { block: proc { |_, j| j.partition.name } },
       'JOB_NUM_NODES' => {
         swagger: { pattern: '^\d+$', description: 'The total number of nodes assigned to the job' },
@@ -72,17 +71,19 @@ module FlightScheduler::Submission
       'JOB_GID'   => { block: proc { |_, j| Etc.getpwnam(j.username).gid } },
 
       # TODO: Confirm what the following env vars should be ¯\_(ツ)_/¯
-      'SUBMIT_HOST'       => { block: proc { `hostname --fqdn`.chomp } },
-      'NODE_ALIASES'      => { block: proc { '(null)' } },
-      'PRIO_PROCESS'      => { block: proc { 0 } },
-      'CPUS_ON_NODE'      => { block: proc { 1 } },
-      'JOB_CPUS_PER_NODE'  => { block: proc { '1(x2)' } },
       'TASKS_PER_NODE'    => { block: proc { '1(x2)' } },
-      'TOPOLOGY_ADDR'     => { block: proc { |n| n.name } },
-      'TOPOLOGY_ADDR_PATTERN'     => { block: proc { |n| n.name.sub(/\[.*\Z/, '') } },
-      'PROCID'            => { block: proc { 0 } },
-      'LOCALID'           => { block: proc { 0 } },
-      'GTIDS'             => { block: proc { 0 } }
+
+      # Other env vars which *may* be required in the future
+      # 'TOPOLOGY_ADDR'     => { block: proc { |n| n.name } },
+      # 'TOPOLOGY_ADDR_PATTERN'     => { block: proc { |n| n.name.sub(/\[.*\Z/, '') } },
+      # 'SUBMIT_HOST'       => { block: proc { `hostname --fqdn`.chomp } },
+      # 'NODE_ALIASES'      => { block: proc { '(null)' } },
+      # 'PRIO_PROCESS'      => { block: proc { 0 } },
+      # 'CPUS_ON_NODE'      => { block: proc { 1 } },
+      # 'JOB_CPUS_PER_NODE'  => { block: proc { '1(x2)' } },
+      # 'PROCID'            => { block: proc { 0 } },
+      # 'LOCALID'           => { block: proc { 0 } },
+      # 'GTIDS'             => { block: proc { 0 } }
     }
 
     ARRAY_ENV_VARS = {


### PR DESCRIPTION
There are some additional env vars required to make MPI jobs run correctly. The are three major changes:

* The env vars are now automatically picked up in the documentation
* The `NODES` env var has been renamed `NUM_NODES` for compatibility with "definitely-not-s..."
* Other env var(s) have been added: `NTASKS`, tba

Technically this PR is a breaking change, but this is to be expected due to the stage the project is in. There is going to be a fair amount of churn/ volatility in the env vars for the imminent future. To help manage the churn it is critical the documentation remains up to date. This allows the envs to be checked without knowing the exact version or running a demo job script to scrape them.

Rebased on #24 to confirm the env vars are being set correctly for array jobs. Please merge it first