### PR TITLE
Set the stdout_path and stderr_path the job/task should write to

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -193,6 +193,8 @@ class App < Sinatra::Base
         end
         property :script, type: :string
         property 'script-name',  type: :string
+        property 'stdout-path', type: :string, description: FlightScheduler::PathGenerator::DESC
+        property 'stderr-path', type: :string, description: FlightScheduler::PathGenerator::DESC
         property :arguments, type: :array do
           items type: :string
         end

--- a/app.rb
+++ b/app.rb
@@ -310,6 +310,8 @@ class App < Sinatra::Base
         partition: FlightScheduler.app.default_partition,
         script_provided: @script ? true : false,
         script_name: attr[:script_name],
+        stdout_path: attr[:stdout_path],
+        stderr_path: attr[:stderr_path],
         state: 'PENDING',
         reason: 'WaitingForScheduling',
         username: current_user

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -36,6 +36,7 @@ class Job
   end
 
   DEFAULT_PATH = 'flight-scheduler-%j.out'
+  ARRAY_DEFAULT_PATH = 'flight-scheduler-%A_%a.out'
   JOB_TYPES = %w( JOB ARRAY_JOB ).freeze
 
   # The index of the task inside the array job.  Only present for ARRAY_TASKS.
@@ -117,7 +118,7 @@ class Job
   validate :validate_array_range, if: ->() { job_type == 'ARRAY_JOB' }
 
   def stdout_path
-    @stdout_path || DEFAULT_PATH
+    @stdout_path || ( job_type == 'ARRAY_JOB' ? ARRAY_DEFAULT_PATH : DEFAULT_PATH )
   end
 
   def stderr_path
@@ -197,6 +198,6 @@ class Task
 
   # Delegates the remaining methods, must be done last
   extend Forwardable
-  def_delegators :@array_job, :partition, :valid?, :script_path
+  def_delegators :@array_job, :partition, :valid?, :script_path, :stdout_path, :stderr_path
   def_delegators :@inner_job, *(Job.instance_methods - self.instance_methods)
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -116,6 +116,7 @@ class Job
   # NOTE: The tasks themselves can be assumed to be valid if the indices are valid
   #       This is because all the other data comes from the ARRAY_JOB itself
   validate :validate_array_range, if: ->() { job_type == 'ARRAY_JOB' }
+  validate :validate_std_paths
 
   def stdout_path
     @stdout_path || ( job_type == 'ARRAY_JOB' ? ARRAY_DEFAULT_PATH : DEFAULT_PATH )
@@ -178,6 +179,15 @@ class Job
 
   def validate_array_range
     @errors.add(:array, 'is not a valid range expression') unless array_range.valid?
+  end
+
+  def validate_std_paths
+    unless FlightScheduler::PathGenerator.valid?(stdout_path)
+      @errors.add(:stdout_path, 'is not a valid path expression')
+    end
+    if !(stdout_path == stderr_path || FlightScheduler::PathGenerator.valid?(stderr_path))
+      @errors.add(:stderr_path, 'is not a valid path expression')
+    end
   end
 end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -35,6 +35,7 @@ class Job
     define_method("#{s.downcase}?") { self.state == s }
   end
 
+  DEFAULT_PATH = 'flight-scheduler-%j.out'
   JOB_TYPES = %w( JOB ARRAY_JOB ).freeze
 
   # The index of the task inside the array job.  Only present for ARRAY_TASKS.
@@ -50,6 +51,9 @@ class Job
   attr_accessor :script_provided
   attr_accessor :state
   attr_accessor :username
+
+  attr_writer :stdout_path
+  attr_writer :stderr_path
 
   attr_writer :reason
   attr_writer :arguments
@@ -111,6 +115,14 @@ class Job
   # NOTE: The tasks themselves can be assumed to be valid if the indices are valid
   #       This is because all the other data comes from the ARRAY_JOB itself
   validate :validate_array_range, if: ->() { job_type == 'ARRAY_JOB' }
+
+  def stdout_path
+    @stdout_path || DEFAULT_PATH
+  end
+
+  def stderr_path
+    @stderr_path || stdout_path
+  end
 
   # Sets the job as an array task
   def array=(range)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -116,7 +116,6 @@ class Job
   # NOTE: The tasks themselves can be assumed to be valid if the indices are valid
   #       This is because all the other data comes from the ARRAY_JOB itself
   validate :validate_array_range, if: ->() { job_type == 'ARRAY_JOB' }
-  validate :validate_std_paths
 
   def stdout_path
     @stdout_path || ( job_type == 'ARRAY_JOB' ? ARRAY_DEFAULT_PATH : DEFAULT_PATH )
@@ -179,15 +178,6 @@ class Job
 
   def validate_array_range
     @errors.add(:array, 'is not a valid range expression') unless array_range.valid?
-  end
-
-  def validate_std_paths
-    unless FlightScheduler::PathGenerator.valid?(stdout_path)
-      @errors.add(:stdout_path, 'is not a valid path expression')
-    end
-    if !(stdout_path == stderr_path || FlightScheduler::PathGenerator.valid?(stderr_path))
-      @errors.add(:stderr_path, 'is not a valid path expression')
-    end
   end
 end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -118,11 +118,17 @@ class Job
   validate :validate_array_range, if: ->() { job_type == 'ARRAY_JOB' }
 
   def stdout_path
-    @stdout_path || ( job_type == 'ARRAY_JOB' ? ARRAY_DEFAULT_PATH : DEFAULT_PATH )
+    if @stdout_path.blank? && job_type == 'ARRAY_JOB'
+      ARRAY_DEFAULT_PATH
+    elsif @stdout_path.blank?
+      DEFAULT_PATH
+    else
+      @stdout_path
+    end
   end
 
   def stderr_path
-    @stderr_path || stdout_path
+    @stderr_path.blank? ? stdout_path : @stderr_path
   end
 
   # Sets the job as an array task

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -109,6 +109,9 @@ class WebsocketApp
       items type: :string
     end
     property :username, type: :string, required: true
+    property :stdout_path, type: :string, required: true, format: :path
+    property :stderr_path, type: :string, required: true, format: :path
+
     prefix = FlightScheduler.app.config.env_var_prefix
     property :environment, required: true do
       property "#{prefix}CLUSTER_NAME", required: true, type: :string,

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -36,6 +36,7 @@ module FlightScheduler
   autoload(:RangeExpander, 'flight_scheduler/range_expander')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
   autoload(:TaskRegistry, 'flight_scheduler/task_registry')
+  autoload(:PathGenerator, 'flight_scheduler/path_generator')
 
   module Cancellation
     autoload(:ArrayJob, 'flight_scheduler/cancellation/array_job')

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -33,10 +33,10 @@ module FlightScheduler
   autoload(:Configuration, 'flight_scheduler/configuration')
   autoload(:DaemonConnections, 'flight_scheduler/daemon_connections')
   autoload(:EventProcessor, 'flight_scheduler/event_processor')
+  autoload(:PathGenerator, 'flight_scheduler/path_generator')
   autoload(:RangeExpander, 'flight_scheduler/range_expander')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
   autoload(:TaskRegistry, 'flight_scheduler/task_registry')
-  autoload(:PathGenerator, 'flight_scheduler/path_generator')
 
   module Cancellation
     autoload(:ArrayJob, 'flight_scheduler/cancellation/array_job')

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -42,8 +42,8 @@ module FlightScheduler
       # 'n' => 'The relative ID of the node within the job',
     }
     ALPHA_KEYS = {
-      'A' => "The ID of the associated job when running an array task, otherwise empty string",
-      'j' => 'The ID of non array task jobs, otherwise empty string',
+      'A' => "The ID of the current tasks's associated job or the job",
+      'j' => 'The ID of the current task or the job',
       'N' => 'The current node name',
       'u' => 'The user name',
       'x' => 'The job name'
@@ -92,11 +92,11 @@ module FlightScheduler
     end
 
     def pct_A
-      task ? job.id : ''
+      job.id
     end
 
     def pct_j
-      task ? '' : job.id
+      task ? task.id : job.id
     end
 
     def pct_N

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -103,9 +103,8 @@ module FlightScheduler
       node.name
     end
 
-    # TODO: Eventually make this the user that submitted the job
     def pct_u
-      Etc.getlogin
+      job.username
     end
 
     def pct_x

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -116,21 +116,15 @@ module FlightScheduler
       path.gsub(PCT_REGEX) do |match|
         if match[-1] == '%' || match.count('%').even?
           match
-        else
+        elsif NUMERIC_KEYS[match[-1]]
           raw = send("pct_#{match[-1]}").to_s
-
-          value = if NUMERIC_KEYS[match[-1]]
-            # Pad numeric chars
-            diff = PAD_REGEX.match(match).captures[0].to_i - raw.length
-            diff = 0 if diff < 0
-            '0' * diff + raw
-          else
-            # Ignore padding for alpha chars
-            raw
-          end
-
-          # Replace the match with the value
-          match.sub(/%[^%]*\Z/, value)
+          diff = PAD_REGEX.match(match).captures[0].to_i - raw.length
+          diff = 0 if diff < 0
+          match.sub(/%[^%]*\Z/, '0' * diff + raw)
+        elsif ALPHA_KEYS[match[-1]]
+          match.sub(/%[^%]*\Z/, send("pct_#{match[-1]}").to_s)
+        else
+          match
         end.gsub('%%', '%')
       end
     end

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -1,0 +1,56 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+module FlightScheduler
+  PathGenerator = Struct.new(:job, :task, :node) do
+    self::NUMERIC_KEYS = {
+      'a' => 'The current index when running an array task, otherwise 0',
+      # TODO: This can't be implemented affectively as the nodes are allocated
+      # to individual array tasks and not the job. This makes determining the
+      # node indexing either inconsistent or impossible to determine
+      #
+      # The allocation behaviour is likely to change TBD. Consider revisiting
+      # 'n' => 'The relative ID of the node within the job',
+    }
+    self::ALPHA_KEYS = {
+      'A' => "The ID of the associate job when running an array task, otherwise empty string",
+      'j' => 'The ID of the running job/task',
+      'N' => 'The current node name',
+      'u' => 'The user name',
+      'x' => 'The job name',
+      '%' => "Escape a literal percent character '%', instead of a special directive"
+    }
+
+    self::DESC = [
+      'The paths may contain various special characters which will be replaced:',
+      '',
+      *self::NUMERIC_KEYS.map { |k, d| " * `%#{k}`: #{d}" },
+      *self::ALPHA_KEYS.map { |k, d| " * `%#{k}`: #{d}" },
+      ' * `%<char>`: All other characters form an invalid replacement'
+    ].join("\n")
+  end
+end

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -59,11 +59,26 @@ module FlightScheduler
     ].join("\n")
 
     ALL_CHARS = [*ALPHA_KEYS.keys, *NUMERIC_KEYS.keys.join('')]
+    LOOKUP_CHAR = ALL_CHARS.map { |k| [k, true] }.to_h
+
     # NOTE: The \\d is converted to \d via string interpolation before typecasting to regex
     PCT_REGEX = Regexp.new "%+\\d*[#{ALL_CHARS.join('')}]?"
     PAD_REGEX = /(\d*).\Z/
+    GENERAL_REGEX = /%+\d*.?/
 
     attr_reader :node, :job, :task
+
+    def self.valid?(path)
+      path.scan(GENERAL_REGEX).all? do |part|
+        if part[-1] == '%' || part.count('%').even?
+          true
+        elsif LOOKUP_CHAR[part[-1]]
+          true
+        else
+          false
+        end
+      end
+    end
 
     def initialize(node:, job:, task: nil)
       @node = node

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -42,7 +42,7 @@ module FlightScheduler
       # 'n' => 'The relative ID of the node within the job',
     }
     ALPHA_KEYS = {
-      'A' => "The ID of the associate job when running an array task, otherwise empty string",
+      'A' => "The ID of the associated job when running an array task, otherwise empty string",
       'j' => 'The ID of non array task jobs, otherwise empty string',
       'N' => 'The current node name',
       'u' => 'The user name',
@@ -58,7 +58,7 @@ module FlightScheduler
       ' * `%<char>`: All other characters form an invalid replacement'
     ].join("\n")
 
-    ALL_CHARS = [*ALPHA_KEYS.keys, *NUMERIC_KEYS.keys.join('')]
+    ALL_CHARS = [*ALPHA_KEYS.keys, *NUMERIC_KEYS.keys]
 
     # NOTE: The \\d is converted to \d via string interpolation before typecasting to regex
     PCT_REGEX = Regexp.new "%+\\d*[#{ALL_CHARS.join('')}]?"

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -59,7 +59,7 @@ module FlightScheduler
     ].join("\n")
 
     ALL_CHARS = [*ALPHA_KEYS.keys, *NUMERIC_KEYS.keys.join('')]
-    PCT_REGEX = Regexp.new "%+[#{ALL_CHARS.join('')}]"
+    PCT_REGEX = Regexp.new "%+[#{ALL_CHARS.join('')}]?"
 
     attr_reader :node, :job, :task
 
@@ -96,7 +96,7 @@ module FlightScheduler
 
     def render(path)
       path.gsub(PCT_REGEX) do |match|
-        if match.count('%').even?
+        if match[-1] == '%' || match.count('%').even?
           match
         else
           value = send("pct_#{match[-1]}")

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -63,21 +63,6 @@ module FlightScheduler
     # NOTE: The \\d is converted to \d via string interpolation before typecasting to regex
     PCT_REGEX = Regexp.new "%+\\d*[#{ALL_CHARS.join('')}]?"
     PAD_REGEX = /(\d*).\Z/
-    GENERAL_REGEX = /%+\d*[^%]?/
-
-    def self.valid?(path)
-      path.scan(GENERAL_REGEX).all? do |part|
-        if part.count('%').even?
-          true
-        elsif NUMERIC_KEYS[part[-1]]
-          true
-        elsif ALPHA_KEYS[part[-1]]
-          PAD_REGEX.match(part).captures[0].empty?
-        else
-          false
-        end
-      end
-    end
 
     attr_reader :node, :job, :task
 

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -28,6 +28,9 @@
 require 'etc'
 
 module FlightScheduler
+  # NOTE: PathGenerator has been deliberately implemented without knowledge of
+  # the data model. This is to prevent coupling to the current implementation
+  # of Task-Job relationship
   PathGenerator = Struct.new(:node, :job, :task) do
     self::NUMERIC_KEYS = {
       'a' => 'The current index when running an array task, otherwise 0',
@@ -54,6 +57,14 @@ module FlightScheduler
       *self::ALPHA_KEYS.map { |k, d| " * `%#{k}`: #{d}" },
       ' * `%<char>`: All other characters form an invalid replacement'
     ].join("\n")
+
+    def pct_a
+      task ? task.array_index : 0
+    end
+
+    def pct_A
+      task ? job.id : ''
+    end
 
     def pct_N
       node.name

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -43,7 +43,7 @@ module FlightScheduler
     }
     self::ALPHA_KEYS = {
       'A' => "The ID of the associate job when running an array task, otherwise empty string",
-      'j' => 'The ID of the running job/task',
+      'j' => 'The ID of non array task jobs, otherwise empty string',
       'N' => 'The current node name',
       'u' => 'The user name',
       'x' => 'The job name',
@@ -64,6 +64,10 @@ module FlightScheduler
 
     def pct_A
       task ? job.id : ''
+    end
+
+    def pct_j
+      task ? '' : job.id
     end
 
     def pct_N

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -118,9 +118,18 @@ module FlightScheduler
           match
         else
           raw = send("pct_#{match[-1]}").to_s
-          diff = PAD_REGEX.match(match).captures[0].to_i - raw.length
-          diff = 0 if diff < 0
-          value = '0' * diff + raw
+
+          value = if NUMERIC_KEYS[match[-1]]
+            # Pad numeric chars
+            diff = PAD_REGEX.match(match).captures[0].to_i - raw.length
+            diff = 0 if diff < 0
+            '0' * diff + raw
+          else
+            # Ignore padding for alpha chars
+            raw
+          end
+
+          # Replace the match with the value
           match.sub(/%[^%]*\Z/, value)
         end.gsub('%%', '%')
       end

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -52,33 +52,34 @@ module FlightScheduler
     DESC = [
       'The paths may contain various special characters which will be replaced:',
       '',
-      *NUMERIC_KEYS.map { |k, d| " * `%#{k}`: #{d}" },
+      *NUMERIC_KEYS.map { |k, d| " * `%\\d*#{k}`: #{d}" },
       *ALPHA_KEYS.map { |k, d| " * `%#{k}`: #{d}" },
       " * `%%`: Escape a literal percent character '%', instead of a special directive",
       ' * `%<char>`: All other characters form an invalid replacement'
     ].join("\n")
 
     ALL_CHARS = [*ALPHA_KEYS.keys, *NUMERIC_KEYS.keys.join('')]
-    LOOKUP_CHAR = ALL_CHARS.map { |k| [k, true] }.to_h
 
     # NOTE: The \\d is converted to \d via string interpolation before typecasting to regex
     PCT_REGEX = Regexp.new "%+\\d*[#{ALL_CHARS.join('')}]?"
     PAD_REGEX = /(\d*).\Z/
     GENERAL_REGEX = /%+\d*.?/
 
-    attr_reader :node, :job, :task
-
     def self.valid?(path)
       path.scan(GENERAL_REGEX).all? do |part|
         if part[-1] == '%' || part.count('%').even?
           true
-        elsif LOOKUP_CHAR[part[-1]]
+        elsif NUMERIC_KEYS[part[-1]]
           true
+        elsif ALPHA_KEYS[part[-1]]
+          PAD_REGEX.match(part).captures[0].empty?
         else
           false
         end
       end
     end
+
+    attr_reader :node, :job, :task
 
     def initialize(node:, job:, task: nil)
       @node = node

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -63,11 +63,11 @@ module FlightScheduler
     # NOTE: The \\d is converted to \d via string interpolation before typecasting to regex
     PCT_REGEX = Regexp.new "%+\\d*[#{ALL_CHARS.join('')}]?"
     PAD_REGEX = /(\d*).\Z/
-    GENERAL_REGEX = /%+\d*.?/
+    GENERAL_REGEX = /%+\d*[^%]?/
 
     def self.valid?(path)
       path.scan(GENERAL_REGEX).all? do |part|
-        if part[-1] == '%' || part.count('%').even?
+        if part.count('%').even?
           true
         elsif NUMERIC_KEYS[part[-1]]
           true

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -25,8 +25,10 @@
 # https://github.com/openflighthpc/flight-scheduler-controller
 #==============================================================================
 
+require 'etc'
+
 module FlightScheduler
-  PathGenerator = Struct.new(:job, :task, :node) do
+  PathGenerator = Struct.new(:node, :job, :task) do
     self::NUMERIC_KEYS = {
       'a' => 'The current index when running an array task, otherwise 0',
       # TODO: This can't be implemented affectively as the nodes are allocated
@@ -52,5 +54,18 @@ module FlightScheduler
       *self::ALPHA_KEYS.map { |k, d| " * `%#{k}`: #{d}" },
       ' * `%<char>`: All other characters form an invalid replacement'
     ].join("\n")
+
+    def pct_N
+      node.name
+    end
+
+    # TODO: Eventually make this the user that submitted the job
+    def pct_u
+      Etc.getlogin
+    end
+
+    def pct_x
+      job.script_name
+    end
   end
 end

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -57,7 +57,9 @@ module FlightScheduler::Submission
           script: job.read_script,
           arguments: job.arguments,
           environment: EnvGenerator.for_array_task(target_node, job, task),
-          username: job.username
+          username: job.username,
+          stdout_path: path_generator.render(task.stdout_path),
+          stderr_path: path_generator.render(task.stderr_path)
         })
         connection.flush
         Async.logger.debug(
@@ -82,5 +84,15 @@ module FlightScheduler::Submission
     private
 
     attr_reader :allocation, :job, :task
+
+    def path_generator
+      @path_generator ||= FlightScheduler::PathGenerator.new(
+        node: target_node, job: job, task: task
+      )
+    end
+
+    def target_node
+      @target_node ||= @allocation.nodes.first
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,5 +40,27 @@ FactoryBot.define do
     arguments { [] }
     array { nil }
     username { 'flight' }
+
+    # Allows the next_task to be progressed so many times
+    # NOTE: The requires the RangeExpander and TaskRegistry to be functioning
+    #       correctly. Consider refactoring
+    transient do
+      num_started { nil }
+      started_state { 'RUNNING' }
+    end
+
+    after(:build) do |job, evaluator|
+      if evaluator.num_started
+        evaluator.num_started.times do
+          job.task_registry.next_task.state = evaluator.started_state
+        end
+      end
+    end
+  end
+
+  factory :node do
+    sequence(:name) { |n| "demo#{n}" }
+
+    initialize_with { new(name: name) }
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe Job, type: :model do
       path = 'some-new-path'
       expect(build(:job, stdout_path: path).stdout_path).to eq(path)
     end
+
+    it 'validates the input' do
+      expect(build(:job, stdout_path: '%%%')).not_to be_valid
+    end
   end
 
   describe '#stderr_path' do
@@ -192,6 +196,10 @@ RSpec.describe Job, type: :model do
     it 'can default to stdout_path' do
       path = 'some-new-path'
       expect(build(:job, stdout_path: path).stderr_path).to eq(path)
+    end
+
+    it 'validates the input' do
+      expect(build(:job, stderr_path: '%%%')).not_to be_valid
     end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -168,6 +168,10 @@ RSpec.describe Job, type: :model do
       expect(build(:job).stdout_path).to eq(described_class::DEFAULT_PATH)
     end
 
+    it 'toggles the default for array jobs' do
+      expect(build(:job, array: '1-2').stdout_path).to eq(described_class::ARRAY_DEFAULT_PATH)
+    end
+
     it 'can be overridden' do
       path = 'some-new-path'
       expect(build(:job, stdout_path: path).stdout_path).to eq(path)

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -176,10 +176,6 @@ RSpec.describe Job, type: :model do
       path = 'some-new-path'
       expect(build(:job, stdout_path: path).stdout_path).to eq(path)
     end
-
-    it 'validates the input' do
-      expect(build(:job, stdout_path: '%%%')).not_to be_valid
-    end
   end
 
   describe '#stderr_path' do
@@ -196,10 +192,6 @@ RSpec.describe Job, type: :model do
     it 'can default to stdout_path' do
       path = 'some-new-path'
       expect(build(:job, stdout_path: path).stderr_path).to eq(path)
-    end
-
-    it 'validates the input' do
-      expect(build(:job, stderr_path: '%%%')).not_to be_valid
     end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -168,6 +168,10 @@ RSpec.describe Job, type: :model do
       expect(build(:job).stdout_path).to eq(described_class::DEFAULT_PATH)
     end
 
+    it 'uses the default instead of empty string' do
+      expect(build(:job, stdout_path: '').stderr_path).to eq(described_class::DEFAULT_PATH)
+    end
+
     it 'toggles the default for array jobs' do
       expect(build(:job, array: '1-2').stdout_path).to eq(described_class::ARRAY_DEFAULT_PATH)
     end
@@ -181,6 +185,10 @@ RSpec.describe Job, type: :model do
   describe '#stderr_path' do
     it 'has a default' do
       expect(build(:job).stderr_path).to eq(described_class::DEFAULT_PATH)
+    end
+
+    it 'uses the default instead of empty string' do
+      expect(build(:job, stderr_path: '').stderr_path).to eq(described_class::DEFAULT_PATH)
     end
 
     it 'can be overridden' do

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -27,6 +27,10 @@
 require 'spec_helper'
 
 RSpec.describe Job, type: :model do
+  it 'is valid' do
+    expect(build(:job)).to be_valid
+  end
+
   describe '#min_nodes' do
     # Ensure the min nodes is overridden
     let(:input_min_nodes) { raise NotImplementedError }
@@ -156,6 +160,34 @@ RSpec.describe Job, type: :model do
           expect(task).to be_valid
         end
       end
+    end
+  end
+
+  describe '#stdout_path' do
+    it 'has a default' do
+      expect(build(:job).stdout_path).to eq(described_class::DEFAULT_PATH)
+    end
+
+    it 'can be overridden' do
+      path = 'some-new-path'
+      expect(build(:job, stdout_path: path).stdout_path).to eq(path)
+    end
+  end
+
+  describe '#stderr_path' do
+    it 'has a default' do
+      expect(build(:job).stderr_path).to eq(described_class::DEFAULT_PATH)
+    end
+
+    it 'can be overridden' do
+      out = 'some-incorrect-path'
+      path = 'some-new-path'
+      expect(build(:job, stdout_path: out, stderr_path: path).stderr_path).to eq(path)
+    end
+
+    it 'can default to stdout_path' do
+      path = 'some-new-path'
+      expect(build(:job, stdout_path: path).stderr_path).to eq(path)
     end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Job, type: :model do
     let(:input_min_nodes) { raise NotImplementedError }
 
     subject do
-      described_class.new(
+      build(:job,
         id: SecureRandom.uuid,
         job_type: 'JOB',
         min_nodes: input_min_nodes,
@@ -79,12 +79,13 @@ RSpec.describe Job, type: :model do
     let(:input_state) { 'RUNNING' }
 
     subject do
-      described_class.new(id: SecureRandom.uuid,
-                          state: input_state,
-                          script_name: 'something.sh',
-                          script_provided: true,
-                          min_nodes: input_min_nodes,
-                          username: 'flight')
+      build(:job,
+        id: SecureRandom.uuid,
+        state: input_state,
+        script_name: 'something.sh',
+        script_provided: true,
+        min_nodes: input_min_nodes
+      )
     end
 
     let(:new_reason) { 'Priority' }
@@ -118,7 +119,7 @@ RSpec.describe Job, type: :model do
 
   describe 'array jobs' do
     let(:job) do
-      described_class.new(
+      build(:job,
         array: input_array,
         id: SecureRandom.uuid,
         min_nodes: 1,

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -88,6 +88,12 @@ RSpec.describe FlightScheduler::PathGenerator do
   end
 
   shared_examples 'shared-attributes' do
+    describe '#pct_A' do
+      it 'returns the job ID' do
+        expect(subject.pct_A).to eq(job.id)
+      end
+    end
+
     describe '#pct_N' do
       it 'returns the node name' do
         expect(subject.pct_N).to eq(node.name)
@@ -219,12 +225,6 @@ RSpec.describe FlightScheduler::PathGenerator do
     include_examples 'shared-attributes'
     include_examples 'render-engine'
 
-    describe '#pct_A' do
-      it 'returns empty string' do
-        expect(subject.pct_A).to eq('')
-      end
-    end
-
     describe '#pct_a' do
       it 'returns 0' do
         expect(subject.pct_a).to eq(0)
@@ -256,12 +256,6 @@ RSpec.describe FlightScheduler::PathGenerator do
     include_examples 'shared-attributes'
     include_examples 'render-engine'
 
-    describe '#pct_A' do
-      it 'returns the job ID' do
-        expect(subject.pct_A).to eq(job.id)
-      end
-    end
-
     describe '#pct_a' do
       it 'returns the task array index' do
         expect(subject.pct_a).to eq(task.array_index)
@@ -270,7 +264,7 @@ RSpec.describe FlightScheduler::PathGenerator do
 
     describe '#pct_j' do
       it 'returns empty string' do
-        expect(subject.pct_j).to eq('')
+        expect(subject.pct_j).to eq(task.id)
       end
     end
   end

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe FlightScheduler::PathGenerator do
     let(:job) { build(:job) }
 
     include_examples 'shared-attributes'
+
+    describe '#pct_A' do
+      it 'returns empty string' do
+        expect(subject.pct_A).to eq('')
+      end
+    end
+
+    describe '#pct_a' do
+      it 'returns 0' do
+        expect(subject.pct_a).to eq(0)
+      end
+    end
   end
 
   context 'with an array job and task' do
@@ -77,6 +89,18 @@ RSpec.describe FlightScheduler::PathGenerator do
     end
 
     include_examples 'shared-attributes'
+
+    describe '#pct_A' do
+      it 'returns the job ID' do
+        expect(subject.pct_A).to eq(job.id)
+      end
+    end
+
+    describe '#pct_a' do
+      it 'returns the task array index' do
+        expect(subject.pct_a).to eq(task.array_index)
+      end
+    end
   end
 end
 

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe FlightScheduler::PathGenerator do
     it "returns true correctly" do
       [
         # General valid inputs
-        '/some/path', '', '%', '%%', '%%%',
+        '/some/path', '', '%%',
         # Basic set of replaced + escaped versions of the chars
         good_set.map do |c|
           [c, "%#{c}", "%%#{c}", "%%%#{c}", "#{rand(20)}#{c}", "%%#{rand(20)}#{c}"]
@@ -68,6 +68,8 @@ RSpec.describe FlightScheduler::PathGenerator do
 
     it "returns false correctly" do
       [
+        # General bad inputs
+        '%', '%%%',
         # Replace versions of unrecognised chars
         bad_set.map do |c|
           ["#{c}%#{c}", "%#{c}", "%#{rand(20)}#{c}", "%%%#{c}", "%%%#{rand(5)}#{c}"]

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe FlightScheduler::PathGenerator do
   subject { raise NotImplementedError }
 
   # TODO: When user + groups are implemented this will need updating
-  let(:user_name) { Etc.getlogin }
-
   describe '::valid?' do
     good_set = described_class::ALL_CHARS
     bad_set = [ 'q', 'w', 'e', '1', '2', '3', '4', '.', '~']
@@ -102,7 +100,7 @@ RSpec.describe FlightScheduler::PathGenerator do
 
     describe '#pct_u' do
       it 'returns the username' do
-        expect(subject.pct_u).to eq(user_name)
+        expect(subject.pct_u).to eq(job.username)
       end
     end
 

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -123,10 +123,8 @@ RSpec.describe FlightScheduler::PathGenerator do
         expect(subject.render('%%')).to eq('%')
       end
 
-      # NOTE: This input is technically unsupported. So it shouldn't break
-      # but beyond this, the response is undefined
-      it 'does not error on %%%' do
-        expect { subject.render('%%%') }.not_to raise_error
+      it 'escapes %%%' do
+        expect(subject.render('%%%')).to eq('%%')
       end
 
       it 'does not render the basic characters' do

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -41,6 +41,36 @@ RSpec.describe FlightScheduler::PathGenerator do
   # TODO: When user + groups are implemented this will need updating
   let(:user_name) { Etc.getlogin }
 
+  describe '::valid?' do
+    good_set = described_class::ALL_CHARS
+    bad_set = [ 'q', 'w', 'e', '1', '2', '3', '4', '.', '~']
+
+    it "returns true correctly" do
+      [
+        '/some/path', '', '%', '%%', '%%%', good_set.map do |c|
+          [c, "%#{c}", "%%#{c}", "%%%#{c}", "#{rand(5)}#{c}", "%#{rand(5)}#{c}",
+          "%%#{rand(5)}#{c}", "%%%#{rand(5)}#{c}"]
+        end,
+        bad_set.map do |c|
+          [c, "%%#{c}", "%%#{rand(5)}#{c}"]
+        end
+      ].flatten.each do |path|
+        expect(described_class.valid?(path)).to(be(true), "expected to be valid: #{path}")
+      end
+    end
+
+    it "returns false false correctly" do
+      bad_set.map do |c|
+        ["#{c}%#{c}", "%#{c}", "%#{rand(5)}#{c}", "%%%#{c}", "%%%#{rand(5)}#{c}"]
+      end.flatten.each do |path|
+        expect(described_class.valid?(path)).to(be(false), "expected not be valid: #{path}")
+
+        prefixed = "%#{good_set.sample}#{path}"
+        expect(described_class.valid?(prefixed)).to(be(false), "expected not be valid: #{prefixed}")
+      end
+    end
+  end
+
   shared_examples 'shared-attributes' do
     describe '#pct_N' do
       it 'returns the node name' do

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -153,10 +153,8 @@ RSpec.describe FlightScheduler::PathGenerator do
         end
       end
 
-      # NOTE: Technically this should only occur for numeric types, however
-      # the implementation is unopinionated for simplicity. Validation is handled separately
-      it 'can pad the response by the requested number of 0' do
-        all_chars.each do |char|
+      it 'can pad numeric chars the requested number of 0' do
+        described_class::NUMERIC_KEYS.keys.each do |char|
           # Randomly set the lengths
           value_length = rand(5)
           pad_length = rand(4) + 1
@@ -174,6 +172,21 @@ RSpec.describe FlightScheduler::PathGenerator do
         end
       end
 
+      it 'ignores the padding directive for alpha chars' do
+        described_class::ALPHA_KEYS.keys.each do |char|
+          # Randomly set the lengths
+          value_length = rand(5)
+
+          # Set the string values
+          method_value = 'A' * value_length
+          allow(subject).to receive("pct_#{char}").and_return(method_value)
+
+          # test the requested path
+          path = "%#{value_length + rand(4) + 1}#{char}"
+          expect(subject.render(path)).to eq(method_value)
+        end
+      end
+
       it 'escapes double percented and preserves the integer' do
         all_chars.each do |char|
           int = rand(5)
@@ -182,8 +195,8 @@ RSpec.describe FlightScheduler::PathGenerator do
         end
       end
 
-      it 'escapes, renders, and pads tripple percented' do
-        all_chars.each do |char|
+      it 'escapes, renders, and pads tripple percented numeric chars' do
+        described_class::NUMERIC_KEYS.keys.each do |char|
           # Randomly set the lengths
           value_length = rand(5)
           pad_length = rand(4) + 1
@@ -198,6 +211,21 @@ RSpec.describe FlightScheduler::PathGenerator do
           path = "%%%#{total_length}#{char}"
           final_value = "%#{padding}#{method_value}"
           expect(subject.render(path)).to eq(final_value)
+        end
+      end
+
+      it 'escapes, and renders but ignores pads for tripple percented alpha chars' do
+        described_class::ALPHA_KEYS.keys.each do |char|
+          # Randomly set the lengths
+          value_length = rand(5)
+
+          # Set the string values
+          method_value = 'A' * value_length
+          allow(subject).to receive("pct_#{char}").and_return(method_value)
+
+          # test the requested path
+          path = "%%%#{value_length + rand(4) + 1}#{char}"
+          expect(subject.render(path)).to eq('%' + method_value)
         end
       end
 

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe FlightScheduler::PathGenerator do
 
   shared_examples 'render-engine' do
     describe '#render' do
+      it 'preserves %' do
+        expect(subject.render('%')).to eq('%')
+      end
+
+      it 'escapes %%' do
+        expect(subject.render('%%')).to eq('%')
+      end
+
+      # NOTE: This input is technically unsupported. So it shouldn't break
+      # but beyond this, the response is undefined
+      it 'does not error on %%%' do
+        expect { subject.render('%%%') }.not_to raise_error
+      end
+
       it 'does not render the basic characters' do
         all_chars.each do |char|
           expect(subject.render(char)).to eq(char)

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -47,22 +47,36 @@ RSpec.describe FlightScheduler::PathGenerator do
 
     it "returns true correctly" do
       [
-        '/some/path', '', '%', '%%', '%%%', good_set.map do |c|
-          [c, "%#{c}", "%%#{c}", "%%%#{c}", "#{rand(5)}#{c}", "%#{rand(5)}#{c}",
-          "%%#{rand(5)}#{c}", "%%%#{rand(5)}#{c}"]
+        # General valid inputs
+        '/some/path', '', '%', '%%', '%%%',
+        # Basic set of replaced + escaped versions of the chars
+        good_set.map do |c|
+          [c, "%#{c}", "%%#{c}", "%%%#{c}", "#{rand(20)}#{c}", "%%#{rand(20)}#{c}"]
         end,
+        # Padded versions of numeric chars
+        described_class::NUMERIC_KEYS.keys.map do |c|
+          [ "%#{rand(5)}#{c}", "%%%#{rand(20)}#{c}"]
+        end,
+        # Escaped versions of unrecognised chars
         bad_set.map do |c|
-          [c, "%%#{c}", "%%#{rand(5)}#{c}"]
+          [c, "%%#{c}", "%%#{rand(20)}#{c}"]
         end
       ].flatten.each do |path|
         expect(described_class.valid?(path)).to(be(true), "expected to be valid: #{path}")
       end
     end
 
-    it "returns false false correctly" do
-      bad_set.map do |c|
-        ["#{c}%#{c}", "%#{c}", "%#{rand(5)}#{c}", "%%%#{c}", "%%%#{rand(5)}#{c}"]
-      end.flatten.each do |path|
+    it "returns false correctly" do
+      [
+        # Replace versions of unrecognised chars
+        bad_set.map do |c|
+          ["#{c}%#{c}", "%#{c}", "%#{rand(20)}#{c}", "%%%#{c}", "%%%#{rand(5)}#{c}"]
+        end,
+        # Padded versions of alpha chars
+        described_class::ALPHA_KEYS.keys.map do |c|
+          [ "%#{rand(20)}#{c}", "%%%#{rand(20)}#{c}"]
+        end
+      ].flatten.each do |path|
         expect(described_class.valid?(path)).to(be(false), "expected not be valid: #{path}")
 
         prefixed = "%#{good_set.sample}#{path}"

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -38,53 +38,6 @@ RSpec.describe FlightScheduler::PathGenerator do
 
   subject { raise NotImplementedError }
 
-  # TODO: When user + groups are implemented this will need updating
-  describe '::valid?' do
-    good_set = described_class::ALL_CHARS
-    bad_set = [ 'q', 'w', 'e', '1', '2', '3', '4', '.', '~']
-
-    it "returns true correctly" do
-      [
-        # General valid inputs
-        '/some/path', '', '%%',
-        # Basic set of replaced + escaped versions of the chars
-        good_set.map do |c|
-          [c, "%#{c}", "%%#{c}", "%%%#{c}", "#{rand(20)}#{c}", "%%#{rand(20)}#{c}"]
-        end,
-        # Padded versions of numeric chars
-        described_class::NUMERIC_KEYS.keys.map do |c|
-          [ "%#{rand(5)}#{c}", "%%%#{rand(20)}#{c}"]
-        end,
-        # Escaped versions of unrecognised chars
-        bad_set.map do |c|
-          [c, "%%#{c}", "%%#{rand(20)}#{c}"]
-        end
-      ].flatten.each do |path|
-        expect(described_class.valid?(path)).to(be(true), "expected to be valid: #{path}")
-      end
-    end
-
-    it "returns false correctly" do
-      [
-        # General bad inputs
-        '%', '%%%',
-        # Replace versions of unrecognised chars
-        bad_set.map do |c|
-          ["#{c}%#{c}", "%#{c}", "%#{rand(20)}#{c}", "%%%#{c}", "%%%#{rand(5)}#{c}"]
-        end,
-        # Padded versions of alpha chars
-        described_class::ALPHA_KEYS.keys.map do |c|
-          [ "%#{rand(20)}#{c}", "%%%#{rand(20)}#{c}"]
-        end
-      ].flatten.each do |path|
-        expect(described_class.valid?(path)).to(be(false), "expected not be valid: #{path}")
-
-        prefixed = "%#{good_set.sample}#{path}"
-        expect(described_class.valid?(prefixed)).to(be(false), "expected not be valid: #{prefixed}")
-      end
-    end
-  end
-
   shared_examples 'shared-attributes' do
     describe '#pct_A' do
       it 'returns the job ID' do

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe FlightScheduler::PathGenerator do
         expect(subject.pct_a).to eq(0)
       end
     end
+
+    describe '#pct_j' do
+      it 'returns the ID' do
+        expect(subject.pct_j).to eq(job.id)
+      end
+    end
   end
 
   context 'with an array job and task' do
@@ -82,7 +88,7 @@ RSpec.describe FlightScheduler::PathGenerator do
     # NOTE The task is deliberately detached from the job. This allows the spec
     # to test various attributes are coming from the `job` instead of task.array_job
     #
-    # This ensure PathGenerator is decoupled from the data model
+    # This ensures PathGenerator is decoupled from the data model
     let(:task_max) { 10 }
     let(:task) do
       build(:job, array: "1-#{task_max}", num_started: rand(task_max - 1)).task_registry.next_task
@@ -99,6 +105,12 @@ RSpec.describe FlightScheduler::PathGenerator do
     describe '#pct_a' do
       it 'returns the task array index' do
         expect(subject.pct_a).to eq(task.array_index)
+      end
+    end
+
+    describe '#pct_j' do
+      it 'returns empty string' do
+        expect(subject.pct_j).to eq('')
       end
     end
   end

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -115,16 +115,20 @@ RSpec.describe FlightScheduler::PathGenerator do
 
   shared_examples 'render-engine' do
     describe '#render' do
-      it 'preserves %' do
-        expect(subject.render('%')).to eq('%')
-      end
+      alpha = (('a'..'z').to_a - described_class::ALL_CHARS).sample
 
-      it 'escapes %%' do
-        expect(subject.render('%%')).to eq('%')
-      end
+      ['', '.', '&', rand(20).to_s, alpha, "#{rand(20)}#{alpha}"].each do |str|
+        it "preserves %#{str}" do
+          expect(subject.render("%#{str}")).to eq("%#{str}")
+        end
 
-      it 'escapes %%%' do
-        expect(subject.render('%%%')).to eq('%%')
+        it "escapes %%#{str}" do
+          expect(subject.render("%%#{str}")).to eq("%#{str}")
+        end
+
+        it "escapes %%%#{str}" do
+          expect(subject.render("%%%#{str}")).to eq("%%#{str}")
+        end
       end
 
       it 'does not render the basic characters' do

--- a/spec/path_generator_spec.rb
+++ b/spec/path_generator_spec.rb
@@ -1,0 +1,32 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+require 'spec_helper'
+
+RSpec.describe FlightScheduler::PathGenerator do
+end
+


### PR DESCRIPTION
The stdout and stderr paths are optional inputs to job creation. They direct the daemon to write the job/task output to the specified location.

They support various replacements that can customise the paths on a per node/job basis. See the documentation for a full list of supported replacements. Note the description is in GFM.
```
curl http://<ip>/v0/docs | jq '.definitions.newJob.properties.attributes.properties["stdout-path"].description'
curl http://<ip>/v0/docs | jq '.definitions.newJob.properties.attributes.properties["stderr-path"].description'
```

This PR is based on #12