### PR TITLE
Add rudimentary authorization/authentication to set the username

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -309,7 +309,8 @@ class App < Sinatra::Base
         script_provided: @script ? true : false,
         script_name: attr[:script_name],
         state: 'PENDING',
-        reason: 'WaitingForScheduling'
+        reason: 'WaitingForScheduling',
+        username: current_user
       )
       next job.id, job
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -49,6 +49,7 @@ class Job
   attr_accessor :script_name
   attr_accessor :script_provided
   attr_accessor :state
+  attr_accessor :username
 
   attr_writer :reason
   attr_writer :arguments
@@ -94,6 +95,8 @@ class Job
   validates :job_type,
     presence: true,
     inclusion: { within: JOB_TYPES }
+
+  validates :username, presence: true
 
   # Validations for `JOB`s.
   validates :min_nodes,

--- a/app/swagger_app.rb
+++ b/app/swagger_app.rb
@@ -49,6 +49,9 @@ class SwaggerApp < Sinatra::Base
         key :name, 'EPL-2.0'
       end
     end
+    security_definition :BasicAuth do
+      key :type, :basic
+    end
   end
 
   SWAGGER_DOC = Swagger::Blocks.build_root_json([WebsocketApp, App, self]).to_json

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -108,6 +108,7 @@ class WebsocketApp
     property :arguments, type: :array, required: true do
       items type: :string
     end
+    property :username, type: :string, required: true
     prefix = FlightScheduler.app.config.env_var_prefix
     property :environment, required: true do
       property "#{prefix}CLUSTER_NAME", required: true, type: :string,

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -57,6 +57,7 @@ module FlightScheduler::Submission
           script: job.read_script,
           arguments: job.arguments,
           environment: EnvGenerator.for_array_task(target_node, job, task),
+          username: job.username
         })
         connection.flush
         Async.logger.debug(

--- a/lib/flight_scheduler/submission/batch_job.rb
+++ b/lib/flight_scheduler/submission/batch_job.rb
@@ -43,6 +43,7 @@ module FlightScheduler::Submission
         script: @job.read_script,
         arguments: @job.arguments,
         environment: EnvGenerator.for_batch(target_node, @job),
+        username: @job.username
       })
       connection.flush
       Async.logger.debug("Sent job #{@job.id} to #{target_node.name}")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,5 +39,6 @@ FactoryBot.define do
     reason { 'WaitingForScheduling' }
     arguments { [] }
     array { nil }
+    username { 'flight' }
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Job, type: :model do
         script_name: 'something.sh',
         script_provided: true,
         state: 'PENDING',
+        username: 'flight'
       )
     end
 
@@ -82,7 +83,8 @@ RSpec.describe Job, type: :model do
                           state: input_state,
                           script_name: 'something.sh',
                           script_provided: true,
-                          min_nodes: input_min_nodes)
+                          min_nodes: input_min_nodes,
+                          username: 'flight')
     end
 
     let(:new_reason) { 'Priority' }
@@ -108,6 +110,12 @@ RSpec.describe Job, type: :model do
     end
   end
 
+  describe '#username' do
+    it 'is invalid if missing' do
+      expect(build(:job, username: nil)).not_to be_valid
+    end
+  end
+
   describe 'array jobs' do
     let(:job) do
       described_class.new(
@@ -117,6 +125,7 @@ RSpec.describe Job, type: :model do
         script_name: 'something.sh',
         script_provided: true,
         state: 'PENDING',
+        username: 'flight'
       )
     end
 


### PR DESCRIPTION
This PR adds `Basic Authorization` which allows the client to send which user executed a job. It then passes the username on as part of the submission to the daemon. 

This PR does not implement the authentication strategy which still needs to be finalised. Instead it focuses on getting the username into the workflow.