### PR TITLE
Allocation execution separation

### DIFF
--- a/app/models/batch_script.rb
+++ b/app/models/batch_script.rb
@@ -1,0 +1,90 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+require 'active_model'
+
+# BatchScript represents a script that a Job may have when it is submitted.
+#
+# Not all jobs have a batch script, e.g., interactive jobs.  If a job has a
+# batch script all of the details for running it are stored here.
+#
+# The batch script will run on a single node allocated to the job.  It may
+# create JobSteps to run on some or all of the nodes allocated to the job.
+#
+class BatchScript
+  include ActiveModel::Model
+
+  DEFAULT_PATH = 'flight-scheduler-%j.out'
+  ARRAY_DEFAULT_PATH = 'flight-scheduler-%A_%a.out'
+
+  attr_accessor :arguments
+  attr_accessor :content
+  attr_accessor :job
+  attr_accessor :name
+
+  attr_writer :stderr_path
+  attr_writer :stdout_path
+
+  validates :content, presence: true
+  validates :job, presence: true
+  validates :name, presence: true
+
+  def stdout_path
+    if @stdout_path.blank? && job.job_type == 'ARRAY_JOB'
+      ARRAY_DEFAULT_PATH
+    elsif @stdout_path.blank?
+      DEFAULT_PATH
+    else
+      @stdout_path
+    end
+  end
+
+  def stderr_path
+    @stderr_path.blank? ? stdout_path : @stderr_path
+  end
+
+  # Must be called at the end of the job lifecycle to remove the script
+  def cleanup
+    FileUtils.rm_rf(File.dirname(path))
+  end
+
+  def write
+    FileUtils.mkdir_p File.dirname(path)
+    File.write(path, content)
+    # We don't want the content hanging around in memory.
+    self.content = nil
+  end
+
+  def content
+    # We deliberately don't cache the value here.
+    @content || File.read(path)
+  rescue Errno::ENOENT
+  end
+
+  def path
+    File.join(FlightScheduler.app.config.spool_dir, 'jobs', job.id.to_s, 'job-script')
+  end
+end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -32,13 +32,12 @@ require 'active_model'
 #
 # A Job may or may not have a "work payload" at the point that it is created.
 #
-# * A batch job will have a submission script at the point that it is created.
-#   The submission script will run on a single node that has been allocated to
+# * A non-array batch job will have a batch script at the point that it is
+#   created.  The script will run on a single node that has been allocated to
 #   the Job.
 #
-# * An array job will have a submission script at the point that it is
-#   created. The submission script will run on all nodes that have been
-#   allocated to the Job.
+# * An array job will have a batch script at the point that it is created. The
+#   script will run on all nodes that have been allocated to the Job.
 #
 # * An interactive job will not have a "work payload" at the point that it is
 #   created.  Once the resources are allocated, the user will be able to add a
@@ -53,8 +52,6 @@ class Job
     define_method("#{s.downcase}?") { self.state == s }
   end
 
-  DEFAULT_PATH = 'flight-scheduler-%j.out'
-  ARRAY_DEFAULT_PATH = 'flight-scheduler-%A_%a.out'
   JOB_TYPES = %w( JOB ARRAY_JOB ARRAY_TASK ).freeze
 
   # The index of the task inside the array job.  Only present for ARRAY_TASKS.
@@ -62,28 +59,26 @@ class Job
 
   # A reference to the ARRAY_JOB.  Only present for ARRAY_TASKS.
   attr_accessor :array_job
-
+  attr_accessor :batch_script
   attr_accessor :id
   attr_accessor :job_type
   attr_accessor :partition
-  attr_accessor :script_name
-  attr_accessor :script_provided
   attr_accessor :state
   attr_accessor :username
 
-  attr_writer :stdout_path
-  attr_writer :stderr_path
-
   attr_writer :reason_pending
-  attr_writer :arguments
 
-  attr_reader :min_nodes
   attr_reader :array_range
+  attr_reader :min_nodes
 
   def initialize(params={})
     # Sets the default job_type to JOB
     self.job_type = 'JOB'
     super
+  end
+
+  def has_batch_script?
+    !!batch_script
   end
 
   # A dummy method that wraps min_nodes until max_nodes is implemented
@@ -126,28 +121,13 @@ class Job
     presence: true,
     numericality: { allow_blank: false, only_integer: true, greater_than_or_equal_to: 1 },
     if: ->() { job_type == 'JOB' }
-  validates :script_name, presence: true, if: ->() { job_type == 'JOB' }
-  validates :script_provided, inclusion: { in: [true] },
-    if: ->() { job_type == 'JOB' }
+
+  validate :validate_batch_script
 
   # Validations the range for array tasks
   # NOTE: The tasks themselves can be assumed to be valid if the indices are valid
   #       This is because all the other data comes from the ARRAY_JOB itself
   validate :validate_array_range, if: ->() { job_type == 'ARRAY_JOB' }
-
-  def stdout_path
-    if @stdout_path.blank? && job_type == 'ARRAY_JOB'
-      ARRAY_DEFAULT_PATH
-    elsif @stdout_path.blank?
-      DEFAULT_PATH
-    else
-      @stdout_path
-    end
-  end
-
-  def stderr_path
-    @stderr_path.blank? ? stdout_path : @stderr_path
-  end
 
   # Sets the job as an array task
   def array=(range)
@@ -164,23 +144,9 @@ class Job
     @reason_pending if pending?
   end
 
-  # Must be called at the end of the job lifecycle to remove the script
+  # Must be called at the end of the job lifecycle.
   def cleanup
-    FileUtils.rm_rf File.dirname(script_path)
-  end
-
-  def write_script(content)
-    FileUtils.mkdir_p File.dirname(script_path)
-    File.write script_path, content
-  end
-
-  def read_script
-    File.read script_path
-  end
-
-  def script_path
-    job_id = job_type == 'ARRAY_TASK' ? array_job.id : self.id
-    File.join(FlightScheduler.app.config.spool_dir, 'jobs', job_id.to_s, 'job-script')
+    batch_script.cleanup if has_batch_script?
   end
 
   def allocated?
@@ -191,17 +157,17 @@ class Job
     FlightScheduler.app.allocations.for_job(self.id)
   end
 
-  # NOTE: Is wrapping the arguments in an array required?
-  #       Confirm the documentation is correct
-  def arguments
-    Array(@arguments)
-  end
-
   def hash
     [self.class, id].hash
   end
 
   def validate_array_range
     @errors.add(:array, 'is not a valid range expression') unless array_range.valid?
+  end
+
+  def validate_batch_script
+    if has_batch_script? && !batch_script.valid?
+      @errors.add(:batch_script, batch_script.errors.full_messages)
+    end
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -166,7 +166,9 @@ class Job
   end
 
   def validate_batch_script
-    if has_batch_script? && !batch_script.valid?
+    if !has_batch_script? && job_type == 'ARRAY_JOB'
+      @errors.add(:batch_script, 'array jobs must have a batch script')
+    elsif has_batch_script? && !batch_script.valid?
       @errors.add(:batch_script, batch_script.errors.full_messages)
     end
   end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -63,7 +63,7 @@ class JobSerializer < BaseSerializer
 
   attribute :min_nodes
   attribute :state
-  attribute :script_name
+  attribute(:script_name) { object.batch_script&.name }
   attribute(:reason) { object.reason_pending }
 
   attribute(:first_index) { object.array_range.expanded.first if object.job_type == 'ARRAY_JOB' }

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -73,7 +73,17 @@ class JobSerializer < BaseSerializer
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }
 
-  has_many(:running_tasks) { object.task_registry.running_tasks(false) if object.job_type == 'ARRAY_JOB' }
+  has_many(:running_tasks) {
+    if object.job_type == 'ARRAY_JOB'
+      object.task_registry.running_tasks(false).each do |task|
+        def task.jsonapi_serializer_class_name
+          'TaskSerializer'
+        end
+      end
+    else
+      nil
+    end
+  }
 end
 
 class TaskSerializer < BaseSerializer

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -34,4 +34,5 @@ FlightScheduler.app.load_configuration
 require 'patches/sinja_request_body_detection'
 
 require_relative '../app/models/allocation'
+require_relative '../app/models/batch_script'
 require_relative '../app/models/job'

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -26,11 +26,11 @@
 #==============================================================================
 
 module FlightScheduler::EventProcessor
-  def batch_job_created(job)
+  def job_created(job)
     FlightScheduler.app.scheduler.add_job(job)
     allocate_resources_and_run_jobs
   end
-  module_function :batch_job_created
+  module_function :job_created
 
   def node_connected
     allocate_resources_and_run_jobs

--- a/lib/flight_scheduler/path_generator.rb
+++ b/lib/flight_scheduler/path_generator.rb
@@ -93,7 +93,7 @@ module FlightScheduler
     end
 
     def pct_x
-      job.script_name
+      job.batch_script.name
     end
 
     def render(path)

--- a/lib/flight_scheduler/submission/array_task.rb
+++ b/lib/flight_scheduler/submission/array_task.rb
@@ -54,12 +54,12 @@ module FlightScheduler::Submission
           job_id: task.id,
           array_job_id: job.id,
           array_task_id: task.id,
-          script: job.read_script,
-          arguments: job.arguments,
+          script: job.batch_script&.content,
+          arguments: job.batch_script&.arguments,
           environment: EnvGenerator.for_array_task(target_node, job, task),
           username: job.username,
-          stdout_path: path_generator.render(task.stdout_path),
-          stderr_path: path_generator.render(task.stderr_path)
+          stdout_path: job.batch_script ? path_generator.render(job.batch_script.stdout_path) : nil,
+          stderr_path: job.batch_script ? path_generator.render(job.batch_script.stderr_path) : nil,
         })
         connection.flush
         Async.logger.debug(

--- a/lib/flight_scheduler/submission/batch_job.rb
+++ b/lib/flight_scheduler/submission/batch_job.rb
@@ -39,12 +39,12 @@ module FlightScheduler::Submission
       connection.write({
         command: 'JOB_ALLOCATED',
         job_id: @job.id,
-        script: @job.read_script,
-        arguments: @job.arguments,
+        script: @job.batch_script&.content,
+        arguments: @job.batch_script&.arguments,
         environment: EnvGenerator.for_batch(target_node, @job),
         username: @job.username,
-        stdout_path: path_generator.render(@job.stdout_path),
-        stderr_path: path_generator.render(@job.stderr_path)
+        stdout_path: @job.batch_script ? path_generator.render(@job.batch_script.stdout_path) : nil,
+        stderr_path: @job.batch_script ? path_generator.render(@job.batch_script.stderr_path) : nil,
       })
       connection.flush
       Async.logger.debug("Sent job #{@job.id} to #{target_node.name}")

--- a/lib/flight_scheduler/submission/batch_job.rb
+++ b/lib/flight_scheduler/submission/batch_job.rb
@@ -39,13 +39,19 @@ module FlightScheduler::Submission
       connection.write({
         command: 'JOB_ALLOCATED',
         job_id: @job.id,
-        script: @job.batch_script&.content,
-        arguments: @job.batch_script&.arguments,
         environment: EnvGenerator.for_batch(target_node, @job),
         username: @job.username,
-        stdout_path: @job.batch_script ? path_generator.render(@job.batch_script.stdout_path) : nil,
-        stderr_path: @job.batch_script ? path_generator.render(@job.batch_script.stderr_path) : nil,
       })
+      if @job.has_batch_script?
+        connection.write({
+          command: 'RUN_SCRIPT',
+          job_id: @job.id,
+          script: @job.batch_script.content,
+          arguments: @job.batch_script.arguments,
+          stdout_path: path_generator.render(@job.batch_script.stdout_path),
+          stderr_path: path_generator.render(@job.batch_script.stderr_path),
+        })
+      end
       connection.flush
       Async.logger.debug("Sent job #{@job.id} to #{target_node.name}")
     rescue

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -128,11 +128,17 @@ class FlightScheduler::TaskRegistry
   def task_enum
     @task_enum ||= Enumerator.new do |yielder|
       job.array_range.each do |idx|
-        yielder << Task.new(
+        yielder << Job.new(
           array_index: idx,
           array_job: job,
           id: SecureRandom.uuid,
-          state: 'PENDING'
+          job_type: 'ARRAY_TASK',
+          min_nodes: 1,
+          partition: job.partition,
+          state: 'PENDING',
+          stderr_path: job.stderr_path,
+          stdout_path: job.stdout_path,
+          username: job.username,
         )
       end
     end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -136,8 +136,6 @@ class FlightScheduler::TaskRegistry
           min_nodes: 1,
           partition: job.partition,
           state: 'PENDING',
-          stderr_path: job.stderr_path,
-          stdout_path: job.stdout_path,
           username: job.username,
         )
       end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe '/jobs' do
       end
 
       it 'writes the script to disk' do
-        expect(File.read response_job.script_path).to eq(script)
+        expect(File.read response_job.batch_script.path).to eq(script)
       end
 
       describe 'DELETE /{id}' do
@@ -157,7 +157,7 @@ RSpec.describe '/jobs' do
         end
 
         it 'deletes the script' do
-          expect(File.exists? response_job.script_path).to be false
+          expect(File.exists? response_job.batch_script.path).to be false
         end
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,11 +33,8 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     partition { FlightScheduler.app.default_partition }
     min_nodes { 1 }
-    script_provided { true } # NOTE: The factory does not actually create the script
-    script_name { 'demo.sh' }
     state { 'PENDING' }
     reason_pending { 'WaitingForScheduling' }
-    arguments { [] }
     array { nil }
     username { 'flight' }
 
@@ -55,6 +52,23 @@ FactoryBot.define do
           job.task_registry.next_task.state = evaluator.started_state
         end
       end
+    end
+  end
+
+  factory :batch_script do
+    arguments { [] }
+    content {
+      <<~EOF
+        #!/bin/bash
+        echo "A batch script"
+      EOF
+    }
+    name { 'my-batch-script.sh' }
+
+    association :job
+
+    after(:build) do |script, evaluator|
+      script.job.batch_script = script
     end
   end
 

--- a/spec/models/allocation_registry_spec.rb
+++ b/spec/models/allocation_registry_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe FlightScheduler::AllocationRegistry, type: :model do
     Job.new(
       id: job_id,
       min_nodes: min_nodes,
-      arguments: [],
       partition: partition,
     )
   end

--- a/spec/models/batch_script.rb
+++ b/spec/models/batch_script.rb
@@ -1,0 +1,74 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+require 'spec_helper'
+
+RSpec.describe BatchScript, type: :model do
+  it 'is valid' do
+    expect(build(:batch_script)).to be_valid
+  end
+
+  describe '#stdout_path' do
+    it 'has a default' do
+      # XXX
+      expect(build(:batch_script).stdout_path).to eq(described_class::DEFAULT_PATH)
+    end
+
+    it 'uses the default instead of empty string' do
+      expect(build(:batch_script, stdout_path: '').stderr_path).to eq(described_class::DEFAULT_PATH)
+    end
+
+    it 'toggles the default for array jobs' do
+      expect(build(:batch_script, array: '1-2').stdout_path).to eq(described_class::ARRAY_DEFAULT_PATH)
+    end
+
+    it 'can be overridden' do
+      path = 'some-new-path'
+      expect(build(:batch_script, stdout_path: path).stdout_path).to eq(path)
+    end
+  end
+
+  describe '#stderr_path' do
+    it 'has a default' do
+      expect(build(:batch_script).stderr_path).to eq(described_class::DEFAULT_PATH)
+    end
+
+    it 'uses the default instead of empty string' do
+      expect(build(:batch_script, stderr_path: '').stderr_path).to eq(described_class::DEFAULT_PATH)
+    end
+
+    it 'can be overridden' do
+      out = 'some-incorrect-path'
+      path = 'some-new-path'
+      expect(build(:batch_script, stdout_path: out, stderr_path: path).stderr_path).to eq(path)
+    end
+
+    it 'can default to stdout_path' do
+      path = 'some-new-path'
+      expect(build(:batch_script, stdout_path: path).stderr_path).to eq(path)
+    end
+  end
+end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe Job, type: :model do
         id: SecureRandom.uuid,
         job_type: 'JOB',
         min_nodes: input_min_nodes,
-        script_name: 'something.sh',
-        script_provided: true,
         state: 'PENDING',
         username: 'flight'
       )
@@ -86,8 +84,6 @@ RSpec.describe Job, type: :model do
       build(:job,
         id: SecureRandom.uuid,
         state: input_state,
-        script_name: 'something.sh',
-        script_provided: true,
         min_nodes: input_min_nodes
       )
     end
@@ -127,8 +123,6 @@ RSpec.describe Job, type: :model do
         array: input_array,
         id: SecureRandom.uuid,
         min_nodes: 1,
-        script_name: 'something.sh',
-        script_provided: true,
         state: 'PENDING',
         username: 'flight'
       )
@@ -160,46 +154,6 @@ RSpec.describe Job, type: :model do
           expect(task).to be_valid
         end
       end
-    end
-  end
-
-  describe '#stdout_path' do
-    it 'has a default' do
-      expect(build(:job).stdout_path).to eq(described_class::DEFAULT_PATH)
-    end
-
-    it 'uses the default instead of empty string' do
-      expect(build(:job, stdout_path: '').stderr_path).to eq(described_class::DEFAULT_PATH)
-    end
-
-    it 'toggles the default for array jobs' do
-      expect(build(:job, array: '1-2').stdout_path).to eq(described_class::ARRAY_DEFAULT_PATH)
-    end
-
-    it 'can be overridden' do
-      path = 'some-new-path'
-      expect(build(:job, stdout_path: path).stdout_path).to eq(path)
-    end
-  end
-
-  describe '#stderr_path' do
-    it 'has a default' do
-      expect(build(:job).stderr_path).to eq(described_class::DEFAULT_PATH)
-    end
-
-    it 'uses the default instead of empty string' do
-      expect(build(:job, stderr_path: '').stderr_path).to eq(described_class::DEFAULT_PATH)
-    end
-
-    it 'can be overridden' do
-      out = 'some-incorrect-path'
-      path = 'some-new-path'
-      expect(build(:job, stdout_path: out, stderr_path: path).stderr_path).to eq(path)
-    end
-
-    it 'can default to stdout_path' do
-      path = 'some-new-path'
-      expect(build(:job, stdout_path: path).stderr_path).to eq(path)
     end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -124,8 +124,10 @@ RSpec.describe Job, type: :model do
         id: SecureRandom.uuid,
         min_nodes: 1,
         state: 'PENDING',
-        username: 'flight'
-      )
+        username: 'flight',
+      ).tap do |job|
+        job.batch_script = build(:batch_script, job: job)
+      end
     end
 
     subject { job }

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Node, type: :model do
     Job.new(
       id: 1,
       min_nodes: 1,
-      arguments: [],
     )
   }
 

--- a/spec/models/partition_spec.rb
+++ b/spec/models/partition_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Partition, type: :model do
     Job.new(
       id: 1,
       min_nodes: '2',
-      arguments: [],
     )
   }
 

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Partition, type: :scheduler do
         id: job_id,
         min_nodes: min_nodes,
         state: 'PENDING',
-        arguments: [],
         partition: partition,
       )
     end


### PR DESCRIPTION
This PR separates resource allocation from running the submission script on the allocated resources.  The motivation for this change is to support interactive jobs and job steps.

Previously, our model assumed that all jobs contained a batch script and that the batch script was the only thing that was going to be exected for a job (at least executed through the scheduler).

Requiring all jobs to contain a batch script is not compatible with interactive jobs.  The lack of support for executing something other than a batch script meant that the equivalent of `srun` could not be supported.  `srun` runs an executable on all nodes allocated to a job.

This PR, extracts knowledge of batch scripts to a new `BatchScript` model.  A `Job` may or may not have reference to a single `BatchScript`.

When a job is allocated resources, we send the `JOB_ALLOCATED` command to the first node allocated.  If the job has a batch script we also send a new `RUN_SCRIPT` command to the first node allocated.  This allows the daemon to separate "job setup" from running the batch script.  This will be important when we come to add job steps and interactive jobs.

I've also removed the `Task` model it was getting in the way of these refactorings and does not currently add anything.  The `TaskRegistry` has been kept and the serializers work as they did before, i.e., they send jobs and tasks as separate things to the client.
