### PR TITLE
Jobs have job steps

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -61,6 +61,7 @@ class Job
   attr_accessor :array_job
   attr_accessor :batch_script
   attr_accessor :id
+  attr_accessor :job_steps
   attr_accessor :job_type
   attr_accessor :partition
   attr_accessor :state
@@ -74,6 +75,9 @@ class Job
   def initialize(params={})
     # Sets the default job_type to JOB
     self.job_type = 'JOB'
+    @next_step_id_mutex = Mutex.new
+    @next_step_id = 0
+    @job_steps = []
     super
   end
 
@@ -100,6 +104,10 @@ class Job
       # This will error during validation with an appropriate error message
       str
     end
+  end
+
+  def next_step_id
+    @next_step_id_mutex.synchronize { @next_step_id += 1 }
   end
 
   # Validations for all job types.

--- a/app/models/job_step.rb
+++ b/app/models/job_step.rb
@@ -24,16 +24,58 @@
 # For more information on FlightSchedulerController, please visit:
 # https://github.com/openflighthpc/flight-scheduler-controller
 #==============================================================================
+require 'active_model'
 
-lib = File.expand_path('../lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+# JobStep is a single parallel step for the Job.  It consists of an executable
+# and arguments to execute.
+#
+# The step will be ran in parallel over all nodes that have been allocated to
+# the job.
+#
+class JobStep
+  include ActiveModel::Model
 
-require 'flight_scheduler'
-FlightScheduler.app.load_configuration
+  attr_accessor :arguments
+  attr_accessor :executions
+  attr_accessor :id
+  attr_accessor :job
+  attr_accessor :path
 
-require 'patches/sinja_request_body_detection'
+  validates :job, presence: true
+  validates :path, presence: true
 
-require_relative '../app/models/allocation'
-require_relative '../app/models/batch_script'
-require_relative '../app/models/job'
-require_relative '../app/models/job_step'
+  def initialize(params={})
+    super
+    self.executions ||= []
+  end
+
+  def add_execution(node)
+    Execution.new(job_step: self, node: node).tap do |execution|
+      self.executions << execution
+    end
+  end
+
+  def execution_for(node_name)
+    executions.detect { |exe| exe.node.name == node_name }
+  end
+
+  # An execution of a job step on a single node.
+  class Execution
+    include ActiveModel::Model
+
+    STATES = %w( RUNNING COMPLETED FAILED ).freeze
+    STATES.each do |s|
+      define_method("#{s.downcase}?") { self.state == s }
+    end
+
+    attr_accessor :job_step
+    attr_accessor :node
+    attr_accessor :state
+
+    validates :job_step, presence: true
+    validates :node, presence: true
+    validates :state,
+      presence: true,
+      inclusion: { within: STATES }
+  end
+end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -86,6 +86,11 @@ class JobSerializer < BaseSerializer
   }
 end
 
+class JobStepSerializer < BaseSerializer
+  attribute :arguments
+  attribute :path
+end
+
 class TaskSerializer < BaseSerializer
   attribute :state
   attribute :min_nodes

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -59,6 +59,16 @@ class MessageProcessor
       job_id = message[:array_job_id]
       FlightScheduler.app.event_processor.node_failed_task(@node_name, task_id, job_id)
 
+    when 'RUN_STEP_COMPLETED'
+      job_id = message[:job_id]
+      step_id = message[:step_id]
+      FlightScheduler.app.event_processor.job_step_completed(@node_name, job_id, step_id)
+
+    when 'RUN_STEP_FAILED'
+      job_id = message[:job_id]
+      step_id = message[:step_id]
+      FlightScheduler.app.event_processor.job_step_failed(@node_name, job_id, step_id)
+
     else
       Async.logger.info("Unknown message #{message}")
     end

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -47,6 +47,7 @@ module FlightScheduler
     autoload(:ArrayTask, 'flight_scheduler/submission/array_task')
     autoload(:BatchJob, 'flight_scheduler/submission/batch_job')
     autoload(:EnvGenerator, 'flight_scheduler/submission/env_generator')
+    autoload(:JobStep, 'flight_scheduler/submission/job_step')
   end
 
   def app

--- a/lib/flight_scheduler/submission/job_step.rb
+++ b/lib/flight_scheduler/submission/job_step.rb
@@ -1,0 +1,76 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+module FlightScheduler::Submission
+  # Run a single job step across all nodes allocated to the step's job.
+  class JobStep
+    def initialize(job_step)
+      @job_step = job_step
+      @job = @job_step.job
+      @allocation = @job.allocation
+    end
+
+    def call
+      @allocation.nodes.each do |node|
+        run_step_on(node)
+      end
+    end
+
+    private
+
+    def run_step_on(node)
+      execution = @job_step.add_execution(node)
+      execution.state = 'RUNNING'
+      connection = FlightScheduler.app.daemon_connections.connection_for(node.name)
+      Async.logger.debug("Sending step #{@job.id}.#{@job_step.id} to #{node.name}")
+      connection.write({
+        command: 'RUN_STEP',
+        arguments: @job_step.arguments,
+        job_id: @job.id,
+        path: @job_step.path,
+        step_id: @job_step.id,
+      })
+      connection.flush
+      Async.logger.debug("Sent step #{@job.id}.#{@job_step.id} to #{node.name}")
+    rescue
+      # XXX What to do here for UnconnectedNode errors?
+      # 1. abort/cancel the entire job
+      # 2. allow the step to run on fewer nodes than we thought
+      # 3. something else?
+      #
+      # XXX What to do for other errors?
+      # * Cancel the job on any nodes?
+      # * Remove the allocation?
+      # * Remove the job from the scheduler?
+      # * More?
+
+      Async.logger.warn(
+        "Error running step #{@job.id}.#{@job_step.id} on #{node.name}: #{$!.message}"
+      )
+    end
+  end
+end


### PR DESCRIPTION
A job step represents a single parallel step for a job.  It consists of an executable and arguments to execute.  The step is ran in parallel over all nodes that have been allocated to the step's job.

The last point highlighted that the method we were using to initialize and run batch jobs was not quite right.  Previously, we were
initializing the environment on only the first allocated node and running the batch script on only that node.  This meant that any job steps ran on other nodes would not have a correctly initialized environment to run in. 

Whilst looking at this I've also discovered that our model for array jobs/tasks is not correct/consistent with slurm.

In slurm, when an array job is created with, say, 4 tasks to run across, say, 2 nodes, *each* task is allocated 2 nodes.  If the nodes were allocated exclusively and each task was to run at the same time, 8 nodes would be allocated to the array job.

In flight scheduler by contrast, *each* task would be allocated a *single* node, resulting in at most 4 nodes being allocated to the job.  The requirement to use 2 nodes, is incorrectly interpreted as a constraint on the maximum number of nodes that can be allocated across the array at any one time.

This commit does not address that issue, but does lay the ground work by adjusting `Submission::ArrayTask` to initialize all nodes that the array task is allocated to.