### PR TITLE
Support connecting job step input/output to run command input/output

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -142,29 +142,37 @@ class App < Sinatra::Base
     end
   end
 
-  resource :job_steps do
+  resource :job_steps, pkre: /[\w.-]+/ do
     helpers do
+      def find(id)
+        job_id, step_id = id.split('.')
+        job = FlightScheduler.app.scheduler.queue.find { |j| j.id == job_id }
+        return nil unless job
+        job.job_steps.detect { |step| step.id.to_s == step_id }
+      end
+
       def validate!
         if @created && resource.validate!
           resource.job.job_steps << resource
           FlightScheduler.app.event_processor.job_step_created(resource)
         end
       end
-
-      create do |attr|
-        @created = true
-        job = FlightScheduler.app.scheduler.queue.find { |j| j.id == attr[:job_id] }
-        step = JobStep.new(
-          arguments: attr[:arguments],
-          job: job,
-          id: job.next_step_id,
-          path: attr[:path],
-          pty: attr[:pty],
-        )
-        next step.id, step
-      end
     end
 
+    create do |attr|
+      @created = true
+      job = FlightScheduler.app.scheduler.queue.find { |j| j.id == attr[:job_id] }
+      step = JobStep.new(
+        arguments: attr[:arguments],
+        job: job,
+        id: job.next_step_id,
+        path: attr[:path],
+        pty: attr[:pty],
+      )
+      next step.id, step
+    end
+
+    show
   end
 
   resource :jobs, pkre: /[\w-]+/ do

--- a/app.rb
+++ b/app.rb
@@ -159,6 +159,7 @@ class App < Sinatra::Base
           job: job,
           id: job.next_step_id,
           path: attr[:path],
+          pty: attr[:pty],
         )
         next step.id, step
       end

--- a/app/models/job_step.rb
+++ b/app/models/job_step.rb
@@ -55,7 +55,11 @@ class JobStep
   end
 
   def add_execution(node)
-    Execution.new(job_step: self, node: node).tap do |execution|
+    Execution.new(
+      id: "#{self.job.id}.#{id}.#{node.name}",
+      job_step: self,
+      node: node,
+    ).tap do |execution|
       self.executions << execution
     end
   end
@@ -68,13 +72,15 @@ class JobStep
   class Execution
     include ActiveModel::Model
 
-    STATES = %w( RUNNING COMPLETED FAILED ).freeze
+    STATES = %w( INITIALIZING RUNNING COMPLETED FAILED ).freeze
     STATES.each do |s|
       define_method("#{s.downcase}?") { self.state == s }
     end
 
+    attr_accessor :id
     attr_accessor :job_step
     attr_accessor :node
+    attr_accessor :port
     attr_accessor :state
 
     validates :job_step, presence: true

--- a/app/models/job_step.rb
+++ b/app/models/job_step.rb
@@ -40,6 +40,7 @@ class JobStep
   attr_accessor :id
   attr_accessor :job
   attr_accessor :path
+  attr_accessor :pty
 
   validates :job, presence: true
   validates :path, presence: true
@@ -47,6 +48,10 @@ class JobStep
   def initialize(params={})
     super
     self.executions ||= []
+  end
+
+  def pty?
+    !!@pty
   end
 
   def add_execution(node)

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -89,6 +89,14 @@ end
 class JobStepSerializer < BaseSerializer
   attribute :arguments
   attribute :path
+
+  has_many(:executions)
+end
+
+class JobStep::ExecutionSerializer < BaseSerializer
+  attribute(:node) { object.node.name }
+  attribute :port
+  attribute :state
 end
 
 class TaskSerializer < BaseSerializer

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -163,8 +163,18 @@ module FlightScheduler::EventProcessor
   end
   module_function :node_deallocated
 
+  def job_step_started(node_name, job_id, step_id, port)
+    Async.logger.info("Node #{node_name} started step:#{step_id} for job #{job_id}")
+    job = FlightScheduler.app.allocations.for_job(job_id).job
+    job_step = job.job_steps.detect { |step| step.id == step_id }
+    execution = job_step.execution_for(node_name)
+    execution.state = 'STARTED'
+    execution.port = port
+  end
+  module_function :job_step_started
+
   def job_step_completed(node_name, job_id, step_id)
-    Async.logger.info("Node #{node_name} completed step for job #{job_id}")
+    Async.logger.info("Node #{node_name} completed step:#{step_id} for job #{job_id}")
     job = FlightScheduler.app.allocations.for_job(job_id).job
     job_step = job.job_steps.detect { |step| step.id == step_id }
     execution = job_step.execution_for(node_name)
@@ -173,7 +183,7 @@ module FlightScheduler::EventProcessor
   module_function :job_step_completed
 
   def job_step_failed(node_name, job_id, step_id)
-    Async.logger.info("Node #{node_name} failed step for job #{job_id}")
+    Async.logger.info("Node #{node_name} failed step:#{step_id} for job #{job_id}")
     job = FlightScheduler.app.allocations.for_job(job_id).job
     job_step = job.job_steps.detect { |step| step.id == step_id }
     execution = job_step.execution_for(node_name)

--- a/lib/flight_scheduler/submission/job_step.rb
+++ b/lib/flight_scheduler/submission/job_step.rb
@@ -37,6 +37,8 @@ module FlightScheduler::Submission
     def call
       @allocation.nodes.each do |node|
         run_step_on(node)
+        # Currently, we only support running PTY sessions on a single node.
+        break if @job_step.pty?
       end
     end
 

--- a/lib/flight_scheduler/submission/job_step.rb
+++ b/lib/flight_scheduler/submission/job_step.rb
@@ -52,6 +52,7 @@ module FlightScheduler::Submission
         arguments: @job_step.arguments,
         job_id: @job.id,
         path: @job_step.path,
+        pty: @job_step.pty?,
         step_id: @job_step.id,
       })
       connection.flush

--- a/lib/flight_scheduler/submission/job_step.rb
+++ b/lib/flight_scheduler/submission/job_step.rb
@@ -44,7 +44,7 @@ module FlightScheduler::Submission
 
     def run_step_on(node)
       execution = @job_step.add_execution(node)
-      execution.state = 'RUNNING'
+      execution.state = 'INITIALIZING'
       connection = FlightScheduler.app.daemon_connections.connection_for(node.name)
       Async.logger.debug("Sending step #{@job.id}.#{@job_step.id} to #{node.name}")
       connection.write({


### PR DESCRIPTION
Support retrieving details of a job step including details of the `stepd`s that are running for it.  This allows the `run` command to connect to the correct socket(s).

If the step is a PTY step, we only run the step on the first node.  This avoids having to connect multiple PTY's STDIN/STDOUT to a single processes STDIN/STDOUT.