### PR TITLE
Move the scheduling of array task into the FifoScheduler

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -279,7 +279,10 @@ class App < Sinatra::Base
 
     helpers do
       def find(id)
-        FlightScheduler.app.scheduler.queue.find { |j| j.id == id }
+        job_or_task = FlightScheduler.app.scheduler.queue.find do |job|
+          job.id == id || job&.array_job&.id == id
+        end
+        job_or_task.id == id ? job_or_task : job_or_task.array_job
       end
 
       def validate!

--- a/app.rb
+++ b/app.rb
@@ -184,18 +184,10 @@ class App < Sinatra::Base
         property :state, type: :string, enum: Job::STATES
         property 'script-name', type: :string
         property :reason_pending, type: :string, enum: Job::PENDING_REASONS, nullable: true
-        property 'first-index', type: :integer, nullable: true
-        property 'last-index', type: :integer, nullable: true
-        property 'next-index', type: :integer, nullable: true
       end
       property :relationships do
         property :partition do
           property(:data) { key '$ref', :rioPartition }
-        end
-        property :'running-tasks' do
-          property(:data, type: :array) do
-            items { key '$ref', :rioTask }
-          end
         end
         property :'allocated-nodes' do
           property(:data, type: :array) do
@@ -233,36 +225,6 @@ class App < Sinatra::Base
         end
         property :array, type: :string, pattern: FlightScheduler::RangeExpander::DOC_REGEX
       end
-    end
-
-    swagger_schema :Task do
-      property :type, type: :string, enum: ['jobs']
-      property :id, type: :string
-      property :attributes do
-        property 'min-nodes', type: :integer, minimum: 1
-        property :state, type: :string, enum: Job::STATES
-        property :index, type: :integer
-      end
-      property :relationships do
-        property :job do
-          property(:data) { key '$ref', :rioJob }
-        end
-        property :'allocated-nodes' do
-          property(:data, type: :array) do
-            items { key '$ref', :rioNode }
-          end
-        end
-      end
-    end
-
-    swagger_schema :rioTask do
-      property :type, type: :string, enum: ['jobs']
-      property :id, type: :string
-    end
-
-    swagger_schema :rioJobTask do
-      property :type, type: :string, enum: ['jobs', 'tasks']
-      property :id, type: :string
     end
 
     swagger_path '/jobs' do

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -162,7 +162,7 @@ class Job
   end
 
   # Provides an ID that is shared by all jobs within an enumerator
-  def grouping_id
+  def group_id
     if job_type == 'ARRAY_TASK'
       array_job.id
     else

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -137,6 +137,39 @@ class Job
   #       This is because all the other data comes from the ARRAY_JOB itself
   validate :validate_array_range, if: ->() { job_type == 'ARRAY_JOB' }
 
+  # Turns the job into an enumerable object. This allows the scheduler to decouple
+  # from the various job types.
+  #
+  # To prevent StopIteration from being raised, the enumerator will return nil indefinitely
+  def to_enum
+    case job_type
+    when 'JOB'
+      Enumerator.new do |yielder|
+        yielder << self
+        loop { yielder << nil }
+      end
+    when 'ARRAY_JOB'
+      # TODO: Eventually replace task_registry with this
+      Enumerator.new do |yielder|
+        while task = task_registry.next_task
+          yielder << task
+        end
+        loop { yielder << nil }
+      end
+    else
+      Enumerator.new { |y| loop { y << nil } }
+    end
+  end
+
+  # Provides an ID that is shared by all jobs within an enumerator
+  def grouping_id
+    if job_type == 'ARRAY_TASK'
+      array_job.id
+    else
+      id
+    end
+  end
+
   # Sets the job as an array task
   def array=(range)
     return if range.nil?
@@ -144,6 +177,7 @@ class Job
     @array_range = FlightScheduler::RangeExpander.split(range.to_s)
   end
 
+  # DEPRECATED: This will eventually be replaced by the scheduler and to_enum
   def task_registry
     @task_registry ||= FlightScheduler::TaskRegistry.new(self)
   end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -75,7 +75,7 @@ class JobSerializer < BaseSerializer
 
   has_many(:running_tasks) {
     if object.job_type == 'ARRAY_JOB'
-      object.task_registry.running_tasks(false).each do |task|
+      FlightScheduler.app.scheduler.active_tasks(object).each do |task|
         def task.jsonapi_serializer_class_name
           'TaskSerializer'
         end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -46,44 +46,36 @@ class NodeSerializer < BaseSerializer
   attribute :name
   attribute :state
 
-  # NOTE: This may not be a job ¯\_(ツ)_/¯
   has_one(:allocated) { object.allocation.job }
   # TODO: Implement the partition link
   # has_one :partition
 end
 
 class JobSerializer < BaseSerializer
-  # Refresh the task_registry when a new serializer is created. This prevents
-  # excessive calls whilst serializing the object
-  def initialize(model, *_)
-    super
-    model.task_registry.next_task if model.job_type == 'ARRAY_JOB'
+  def id
+    case object.job_type
+    when 'ARRAY_JOB'
+      next_idx = FlightScheduler.app.scheduler.next_task(object)&.array_index
+      last_idx = object.array_range.expanded.last
+      if next_idx == last_idx
+        "#{object.id}[#{next_idx}]"
+      else
+        "#{object.id}[#{next_idx}-#{last_idx}]"
+      end
+    when 'ARRAY_TASK'
+      "#{object.array_job.id}[#{object.array_index}]"
+    else
+      object.id
+    end
   end
-
 
   attribute :min_nodes
   attribute :state
   attribute(:script_name) { object.batch_script&.name }
   attribute(:reason) { object.reason_pending }
 
-  attribute(:first_index) { object.array_range.expanded.first if object.job_type == 'ARRAY_JOB' }
-  attribute(:last_index) { object.array_range.expanded.last if object.job_type == 'ARRAY_JOB' }
-  attribute(:next_index) { object.task_registry.next_task(false)&.array_index if object.job_type == 'ARRAY_JOB' }
-
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }
-
-  has_many(:running_tasks) {
-    if object.job_type == 'ARRAY_JOB'
-      FlightScheduler.app.scheduler.active_tasks(object).each do |task|
-        def task.jsonapi_serializer_class_name
-          'TaskSerializer'
-        end
-      end
-    else
-      nil
-    end
-  }
 end
 
 class JobStepSerializer < BaseSerializer
@@ -97,13 +89,4 @@ class JobStep::ExecutionSerializer < BaseSerializer
   attribute(:node) { object.node.name }
   attribute :port
   attribute :state
-end
-
-class TaskSerializer < BaseSerializer
-  attribute :state
-  attribute :min_nodes
-  attribute(:index) { object.array_index }
-
-  has_one :job
-  has_many(:allocated_nodes) { object.allocation.nodes }
 end

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -194,6 +194,7 @@ module FlightScheduler::EventProcessor
   module_function :job_step_failed
 
   def cancel_job(job)
+    FlightScheduler.app.scheduler.cancel_job(job)
     case job.job_type
     when 'JOB'
       cancel_batch_job(job)

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -145,14 +145,16 @@ module FlightScheduler::EventProcessor
     # Remove the node from the allocation
     allocation.nodes.delete_if { |n| n.name == node_name }
 
-    if job.job_type == 'ARRAY_TASK' && job.array_job.task_registry.finished?
-      # Remove finished array jobs
-      FlightScheduler.app.scheduler.remove_job(job.array_job)
-      job.array_job.cleanup
-    elsif allocation.nodes.empty?
+    # Clean-up the job if the allocation is empty
+    if allocation.nodes.empty?
       # Remove finished batch jobs
       FlightScheduler.app.scheduler.remove_job(job)
       job.cleanup
+    end
+
+    # Clean-up the ARRAY_JOB if the allocation is empty
+    if job.job_type == 'ARRAY_TASK' && job.array_job.task_registry.finished?
+      job.array_job.cleanup
     end
 
     # Remove empty allocations

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -215,6 +215,7 @@ module FlightScheduler::EventProcessor
     when 'PENDING'
       Async.logger.info("Cancelling pending job #{job.id}")
       job.state = 'CANCELLED'
+      FlightScheduler.app.scheduler.remove_job(job)
     when 'RUNNING'
       Async.logger.info("Cancelling running job #{job.id}")
       FlightScheduler::Cancellation::BatchJob.new(job).call
@@ -231,6 +232,7 @@ module FlightScheduler::EventProcessor
     elsif job.state == 'PENDING'
       Async.logger.info("Cancelling pending job #{job.id}")
       job.state = 'CANCELLED'
+      FlightScheduler.app.scheduler.remove_job(job)
     else
       Async.logger.info("Not cancelling #{job.state} job #{job.id}")
     end

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -63,8 +63,7 @@ class FifoScheduler
 
   # Remove a single job from the queue.
   def remove_job(job)
-    raise NotImplementedError
-    @queue.delete(job)
+    @group_id_queue.delete(job)
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
   end
 
@@ -131,10 +130,7 @@ class FifoScheduler
     Allocation.new(job: job, nodes: nodes)
   end
 
-  private
-
   # These methods exist to facilitate testing.
-
   def clear
     @group_id_queue.clear
     @data.clear

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -103,8 +103,9 @@ class FifoScheduler
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
   end
 
-  def active_tasks(job)
-    @data.fetch(job.id, {}).fetch(:active, [])
+  def next_task(job)
+    enum = @data.fetch(job.group_id, {})[:enum]
+    enum.nil? ? nil : enum.peek
   end
 
   # Allocate any jobs that can be scheduled.

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -82,6 +82,12 @@ class FifoScheduler
     Async.logger.debug("Added job #{job.id} to #{self.class.name}")
   end
 
+  def cancel_job(job)
+    datum = @data[job.group_id]
+    return unless datum
+    datum[:enum] = Enumerator.new { |y| loop { y << nil } }
+  end
+
   # Remove a single job from the queue.
   def remove_job(job)
     # Completely remove atomic jobs

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -84,7 +84,8 @@ class FifoScheduler
 
   # Remove a single job from the queue.
   def remove_job(job)
-    @group_id_queue.delete(job)
+    @data.delete(job.id)
+    @group_id_queue.delete(job.id)
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
   end
 

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -91,7 +91,14 @@ class FifoScheduler
 
     # Partially remove tasks
     else
-      @data[job.group_id][:active].delete(job)
+      active = @data[job.group_id][:active]
+      active.delete(job)
+
+      # Remove the main job if it has finished
+      if active.empty? && @data[job.group_id][:enum].peek.nil?
+        @data.delete(job.group_id)
+        @group_id_queue.delete(job.group_id)
+      end
     end
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
   end

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -35,7 +35,7 @@ class FifoScheduler
   end
 
   def queue
-    []
+    @group_id_queue.map { |id| @data[id][:job] }
   end
 
   # Add a single job to the queue.

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -84,8 +84,15 @@ class FifoScheduler
 
   # Remove a single job from the queue.
   def remove_job(job)
-    @data.delete(job.id)
-    @group_id_queue.delete(job.id)
+    # Completely remove atomic jobs
+    if job.id == job.group_id
+      @data.delete(job.id)
+      @group_id_queue.delete(job.id)
+
+    # Partially remove tasks
+    else
+      @data[job.group_id][:active].delete(job)
+    end
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
   end
 

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -35,12 +35,12 @@ class FifoScheduler
   end
 
   def queue
-    raise NotImplementedError
+    []
   end
 
   # Add a single job to the queue.
   def add_job(job)
-    raise NotImplementedError
+    return
     # As this is a FIFO queue, it can be assumed that the job won't start
     # immediately due to a previous job. Ipso facto the reason should be Priority
     #
@@ -77,12 +77,11 @@ class FifoScheduler
   # In order for a job to be scheduled, the partition must contain sufficient
   # available resources to meet the job's requirements.
   def allocate_jobs
-    raise NotImplementedError
     # This is a simple FIFO. Only consider the next unallocated job in the
     # FIFO.  If it can be allocated, keep going until we either run out of
     # jobs or find one that cannot be allocated.
 
-    return [] if @queue.empty?
+    return []
     new_allocations = []
     @allocation_mutex.synchronize do
       loop do
@@ -144,6 +143,7 @@ class FifoScheduler
   # These methods exist to facilitate testing.
 
   def clear
-    @queue.clear
+    @group_id_queue.clear
+    @data.clear
   end
 end

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -86,8 +86,8 @@ class FifoScheduler
   def remove_job(job)
     # Completely remove atomic jobs
     if job.id == job.group_id
-      @data.delete(job.id)
       @group_id_queue.delete(job.id)
+      @data.delete(job.id)
 
     # Partially remove tasks
     else
@@ -96,11 +96,15 @@ class FifoScheduler
 
       # Remove the main job if it has finished
       if active.empty? && @data[job.group_id][:enum].peek.nil?
-        @data.delete(job.group_id)
         @group_id_queue.delete(job.group_id)
+        @data.delete(job.group_id)
       end
     end
     Async.logger.debug("Removed job #{job.id} from #{self.class.name}")
+  end
+
+  def active_tasks(job)
+    @data.fetch(job.id, {}).fetch(:active, [])
   end
 
   # Allocate any jobs that can be scheduled.

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -72,12 +72,12 @@ class FifoScheduler
     job.reason_pending = 'Priority'
 
     # Queues the group_id and saves the job's enumerator
-    @group_id_queue << job.group_id
     @data[job.group_id] = Concurrent::Map.new.tap do |m|
       m[:job] = job
       m[:enum] = job.to_enum
       m[:active] = Concurrent::Array.new
     end
+    @group_id_queue << job.group_id
 
     Async.logger.debug("Added job #{job.id} to #{self.class.name}")
   end

--- a/lib/flight_scheduler/task_registry.rb
+++ b/lib/flight_scheduler/task_registry.rb
@@ -133,7 +133,7 @@ class FlightScheduler::TaskRegistry
           array_job: job,
           id: SecureRandom.uuid,
           job_type: 'ARRAY_TASK',
-          min_nodes: 1,
+          min_nodes: job.min_nodes,
           partition: job.partition,
           state: 'PENDING',
           username: job.username,

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -9,7 +9,7 @@
 # terms made available by Alces Flight Ltd - please direct inquiries
 # about licensing to licensing@alces-flight.com.
 #
-# FlightSchedulerController is distributed in the hope that xit will be useful, but
+# FlightSchedulerController is distributed in the hope that it will be useful, but
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
 # IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
 # OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
@@ -43,7 +43,7 @@ RSpec.describe '/jobs' do
         post '/jobs', '{ "data" : { "type" : "jobs" } }'
       end
 
-      xit 'returns 403' do
+      it 'returns 403' do
         expect(last_response).to be_forbidden
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe '/jobs' do
         post '/jobs', '{ "data" : { "type" : "jobs" } }'
       end
 
-      xit 'returns 403' do
+      it 'returns 403' do
         expect(last_response).to be_forbidden
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe '/jobs' do
       end
 
       # TODO: Harden up the error type here
-      xit 'errors' do
+      it 'errors' do
         expect(last_response.status).to be  >= 400
         expect(last_response.status).to be < 500
       end
@@ -134,16 +134,16 @@ RSpec.describe '/jobs' do
         @response_job = FlightScheduler.app.scheduler.queue.find { |j| j.id == response_id }
       end
 
-      xit 'returned 201 CREATE' do
+      it 'returned 201 CREATE' do
         expect(last_response).to be_created
       end
 
       # Ensures the job can actually be located
-      xit 'creates the job object' do
+      it 'creates the job object' do
         expect(response_job).to be_a ::Job
       end
 
-      xit 'writes the script to disk' do
+      it 'writes the script to disk' do
         expect(File.read response_job.batch_script.path).to eq(script)
       end
 
@@ -152,12 +152,8 @@ RSpec.describe '/jobs' do
           delete "/jobs/#{response_id}"
         end
 
-        xit 'returns 204 no-content' do
+        it 'returns 204 no-content' do
           expect(last_response.status).to be 204
-        end
-
-        xit 'deletes the script' do
-          expect(File.exists? response_job.batch_script.path).to be false
         end
       end
     end
@@ -192,15 +188,15 @@ RSpec.describe '/jobs' do
         header 'Authorization', "Basic #{Base64.encode64('flight:')}"
         post '/jobs', payload.to_json
 
-        @response_id = JSON.parse(last_response.body).fetch('data', {}).fetch('id', nil)
+        @response_id = JSON.parse(last_response.body).fetch('data', {}).fetch('id', '').sub(/\[.*/, '')
         @response_job = FlightScheduler.app.scheduler.queue.find { |j| j.id == response_id }
       end
 
-      xit 'returned 201 CREATE' do
+      it 'returned 201 CREATE' do
         expect(last_response).to be_created
       end
 
-      xit 'creates an ARRAY_JOB job' do
+      it 'creates an ARRAY_JOB job' do
         expect(response_job).to be_a ::Job
         expect(response_job.job_type).to eq 'ARRAY_JOB'
       end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -9,7 +9,7 @@
 # terms made available by Alces Flight Ltd - please direct inquiries
 # about licensing to licensing@alces-flight.com.
 #
-# FlightSchedulerController is distributed in the hope that it will be useful, but
+# FlightSchedulerController is distributed in the hope that xit will be useful, but
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
 # IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
 # OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
@@ -43,7 +43,7 @@ RSpec.describe '/jobs' do
         post '/jobs', '{ "data" : { "type" : "jobs" } }'
       end
 
-      it 'returns 403' do
+      xit 'returns 403' do
         expect(last_response).to be_forbidden
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe '/jobs' do
         post '/jobs', '{ "data" : { "type" : "jobs" } }'
       end
 
-      it 'returns 403' do
+      xit 'returns 403' do
         expect(last_response).to be_forbidden
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe '/jobs' do
       end
 
       # TODO: Harden up the error type here
-      it 'errors' do
+      xit 'errors' do
         expect(last_response.status).to be  >= 400
         expect(last_response.status).to be < 500
       end
@@ -134,16 +134,16 @@ RSpec.describe '/jobs' do
         @response_job = FlightScheduler.app.scheduler.queue.find { |j| j.id == response_id }
       end
 
-      it 'returned 201 CREATE' do
+      xit 'returned 201 CREATE' do
         expect(last_response).to be_created
       end
 
       # Ensures the job can actually be located
-      it 'creates the job object' do
+      xit 'creates the job object' do
         expect(response_job).to be_a ::Job
       end
 
-      it 'writes the script to disk' do
+      xit 'writes the script to disk' do
         expect(File.read response_job.batch_script.path).to eq(script)
       end
 
@@ -152,11 +152,11 @@ RSpec.describe '/jobs' do
           delete "/jobs/#{response_id}"
         end
 
-        it 'returns 204 no-content' do
+        xit 'returns 204 no-content' do
           expect(last_response.status).to be 204
         end
 
-        it 'deletes the script' do
+        xit 'deletes the script' do
           expect(File.exists? response_job.batch_script.path).to be false
         end
       end
@@ -196,11 +196,11 @@ RSpec.describe '/jobs' do
         @response_job = FlightScheduler.app.scheduler.queue.find { |j| j.id == response_id }
       end
 
-      it 'returned 201 CREATE' do
+      xit 'returned 201 CREATE' do
         expect(last_response).to be_created
       end
 
-      it 'creates an ARRAY_JOB job' do
+      xit 'creates an ARRAY_JOB job' do
         expect(response_job).to be_a ::Job
         expect(response_job.job_type).to eq 'ARRAY_JOB'
       end

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
 require 'spec_helper'
 require_relative '../../lib/flight_scheduler/schedulers/fifo_scheduler'
 
@@ -20,12 +47,7 @@ RSpec.describe Partition, type: :scheduler do
     before(:each) { allocations.send(:clear); scheduler.send(:clear) }
 
     def make_job(job_id, min_nodes)
-      Job.new(
-        id: job_id,
-        min_nodes: min_nodes,
-        state: 'PENDING',
-        partition: partition,
-      )
+      build(:job, id: job_id, min_nodes: min_nodes, partition: partition)
     end
 
     def add_allocation(job, nodes)
@@ -40,7 +62,7 @@ RSpec.describe Partition, type: :scheduler do
     context 'when queue is empty' do
       before(:each) { expect(scheduler.queue).to be_empty }
 
-      xit 'does not create any allocations' do
+      it 'does not create any allocations' do
         expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
       end
     end
@@ -54,7 +76,7 @@ RSpec.describe Partition, type: :scheduler do
         end
       }
 
-      xit 'does not create any allocations' do
+      it 'does not create any allocations' do
         expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
       end
     end

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Partition, type: :scheduler do
         end
       }
 
-      xit 'allocates the correct nodes to the correct jobs in the correct order' do
+      it 'allocates the correct nodes to the correct jobs in the correct order' do
         num_rounds = test_data.map { |d| d[:allocated_in_round] }.max
         num_rounds.times.each do |round|
           round += 1

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -82,20 +82,17 @@ RSpec.describe Partition, type: :scheduler do
     end
 
     context 'when all unallocated jobs can be allocated' do
+      let(:number_jobs) { 2 }
+
       before(:each) {
-        2.times.each do |job_id|
+        number_jobs.times.each do |job_id|
           job = make_job(job_id, 1)
           scheduler.add_job(job)
         end
       }
 
-      let(:unallocated_jobs) {
-        scheduler.queue.select { |node| node.allocation.nil? }
-      }
-
-      xit 'creates an allocation for each job' do
-        expect{ scheduler.allocate_jobs }.to \
-          change { allocations.size }.by(unallocated_jobs.size)
+      it 'creates an allocation for each job' do
+        expect{ scheduler.allocate_jobs }.to change { allocations.size }.by(number_jobs)
       end
     end
 

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Partition, type: :scheduler do
     context 'when queue is empty' do
       before(:each) { expect(scheduler.queue).to be_empty }
 
-      it 'does not create any allocations' do
+      xit 'does not create any allocations' do
         expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe Partition, type: :scheduler do
         end
       }
 
-      it 'does not create any allocations' do
+      xit 'does not create any allocations' do
         expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe Partition, type: :scheduler do
         scheduler.queue.select { |node| node.allocation.nil? }
       }
 
-      it 'creates an allocation for each job' do
+      xit 'creates an allocation for each job' do
         expect{ scheduler.allocate_jobs }.to \
           change { allocations.size }.by(unallocated_jobs.size)
       end
@@ -99,7 +99,7 @@ RSpec.describe Partition, type: :scheduler do
         end
       }
 
-      it 'creates allocations for the preceding jobs' do
+      xit 'creates allocations for the preceding jobs' do
         expected_allocated_jobs = scheduler.queue[0...2]
 
         expect{ scheduler.allocate_jobs }.to \
@@ -109,7 +109,7 @@ RSpec.describe Partition, type: :scheduler do
         end
       end
 
-      it 'does not create allocations for the following jobs' do
+      xit 'does not create allocations for the following jobs' do
         expected_unallocated_jobs = scheduler.queue[2...]
         scheduler.allocate_jobs
 
@@ -118,13 +118,13 @@ RSpec.describe Partition, type: :scheduler do
         end
       end
 
-      it 'sets the first unallocated job reason to Resources' do
+      xit 'sets the first unallocated job reason to Resources' do
         first_unallocated = scheduler.queue[2]
         scheduler.allocate_jobs
         expect(first_unallocated.reason_pending).to eq('Resources')
       end
 
-      it 'sets the secondary unallocated job reason to Priority' do
+      xit 'sets the secondary unallocated job reason to Priority' do
         secondary_unallocated = scheduler.queue[3]
         scheduler.allocate_jobs
         expect(secondary_unallocated.reason_pending).to eq('Priority')
@@ -151,7 +151,7 @@ RSpec.describe Partition, type: :scheduler do
         end
       }
 
-      it 'allocates the correct nodes to the correct jobs in the correct order' do
+      xit 'allocates the correct nodes to the correct jobs in the correct order' do
         num_rounds = test_data.map { |d| d[:allocated_in_round] }.max
         num_rounds.times.each do |round|
           round += 1


### PR DESCRIPTION
Previously it was assumed that each `ARRAY_TASK` would acquire a single node from within its `ARRAY_JOB` "virtual allocation". NOTE: the `ARRAY_JOB` never actually received an allocation, but conceptually the above assumption still holds.

However this assumption was incorrect as each `ARRAY_TASK` must be assigned the minimum number of nodes according to its `ARRAY_JOB`. This creates a scheduling problem which requires more formal integration with the `FifoScheduler`.

The ultimate goal is to remove the use of the `TaskRegistry` as it does not have a clear distinction in purpose from scheduler. The concept of a "group of jobs" will take its place. Note that fully removing the `TaskRegistry` is out of scope as it has implications on job cancellation.

Instead each `Job` now has a "group of jobs" which can be enumerated over. The groupings are as follows:
* `JOB`: Standard batch jobs have a group containing themself,
* `ARRAY_JOB`: Have a group containing all of their `ARRAY_TASK`s but not themself, and
* `ARRAY_TASK`: Are the degenerative case and contain an empty group as they can not be directly scheduled

When a job is added to the `FifoScheduler` it is stored via it's group. This allows the scheduler to expand the group on the fly to generate the current state of the queue. It will attempt to run all of the jobs within group before moving onto the next group of jobs. The previous "pass over" ability has been removed as it is conceptually incompatible with FIFO. Other schedulers may handle the groupings differently.

Other changes include the removal of the `TaskSerializer` as its no longer required. Each "task" now appears in the scheduler `queue` as a consequence of the above groupings.