### PR TITLE
Store the profiled information on the node

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -40,6 +40,19 @@ class Node
 
     attr_accessor(*DELEGATES)
     validates(*DELEGATES, allow_nil: true, numericality: { only_integers: true })
+
+    def to_h
+      self.class::DELEGATES.each_with_object({}) do |key, memo|
+        memo[key] = self.send(key)
+      end
+    end
+
+    def ==(other)
+      return false unless other.class == self.class
+      self.class::DELEGATES.all? do |key|
+        self.send(key) == other.send(key)
+      end
+    end
   end
 
   extend Forwardable

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -39,7 +39,7 @@ class Node
     DELEGATES = [:cpus, :gpus, :memory]
 
     attr_accessor(*DELEGATES)
-    validates(*DELEGATES, presence: false, numericality: { only_integers: true })
+    validates(*DELEGATES, allow_nil: true, numericality: { only_integers: true })
   end
 
   extend Forwardable

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -45,6 +45,9 @@ class NodeSerializer < BaseSerializer
 
   attribute :name
   attribute :state
+  attribute :cpus
+  attribute :gpus
+  attribute :memory
 
   has_one(:allocated) { object.allocation.job }
   # TODO: Implement the partition link

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -256,12 +256,22 @@ class WebsocketApp
     attributes.gpus   = message[:gpus]    if message.key?(:gpus)
     attributes.memory = message[:memory]  if message.key?(:memory)
 
-    if attributes.valid?
+    if attributes == node.attributes
+      Async.logger.debug <<~ATTRIBUTES.chomp
+        Unchanged '#{node_name}' attributes:
+        #{attributes.to_h.map { |k, v| "#{k}: #{v}" }.join("\n")}
+      ATTRIBUTES
+    elsif attributes.valid?
+      Async.logger.info <<~ATTRIBUTES.chomp
+        Updating '#{node_name}' attributes:
+        #{attributes.to_h.map { |k, v| "#{k}: #{v}" }.join("\n")}
+      ATTRIBUTES
+
       node.attributes = attributes
     else
       Async.logger.error <<~ERROR
         Invalid node attributes for #{node.name}:
-        #{node.attributes.errors.messages}
+        #{attributes.errors.messages}
       ERROR
     end
   end

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -249,7 +249,7 @@ class WebsocketApp
         unless message.is_a?(Hash) && message[:command] == 'CONNECTED'
           Async.logger.info("Badly formed connection message #{message.inspect}")
           connection.close
-          break
+          next
         end
 
         begin

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -83,7 +83,10 @@ class WebsocketApp
 
   swagger_schema :connectedWS do
     property :command, type: :string, required: true, enum: ['CONNECTED']
-    property :node, type: :string, required: true
+    property :node,   type: :string,  required: true
+    property :cpus,   type: :integer, required: false
+    property :gpus,   type: :integer, required: false
+    property :memory, type: :integer, required: false
   end
 
   swagger_schema :nodeCompletedJobWS do
@@ -242,6 +245,27 @@ class WebsocketApp
     end
   end
 
+  def update_node_attributes(node_name, message)
+    node = FlightScheduler.app.default_partition.nodes.find do |n|
+      n.name == node_name
+    end
+    return unless node
+
+    attributes = node.attributes.dup
+    attributes.cpus   = message[:cpus]    if message.key?(:cpus)
+    attributes.gpus   = message[:gpus]    if message.key?(:gpus)
+    attributes.memory = message[:memory]  if message.key?(:memory)
+
+    if attributes.valid?
+      node.attributes = attributes
+    else
+      Async.logger.error <<~ERROR
+        Invalid node attributes for #{node.name}:
+        #{node.attributes.errors.messages}
+      ERROR
+    end
+  end
+
   def call(env)
     Async::WebSocket::Adapters::Rack.open(env) do |connection|
       begin
@@ -253,22 +277,23 @@ class WebsocketApp
         end
 
         begin
-          node = FlightScheduler::Auth.node_from_token(message[:auth_token])
+          node_name = FlightScheduler::Auth.node_from_token(message[:auth_token])
         rescue FlightScheduler::Auth::AuthenticationError
           Async.logger.info("Could not authenticate connection: #{$!.message}")
           connection.close
         else
           begin
-            Async.logger.info("#{node.inspect} connected")
-            processor = MessageProcessor.new(node, connection)
-            connections.add(node, processor)
+            update_node_attributes(node_name, message)
+            Async.logger.info("#{node_name.inspect} connected")
+            processor = MessageProcessor.new(node_name, connection)
+            connections.add(node_name, processor)
             Async.logger.debug("Connected nodes #{connections.connected_nodes}")
             while message = connection.read
               processor.call(message)
             end
             connection.close
           ensure
-            Async.logger.info("#{node.inspect} disconnected")
+            Async.logger.info("#{node_name.inspect} disconnected")
             connections.remove(processor)
             Async.logger.debug("Connected nodes #{connections.connected_nodes}")
           end

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -246,9 +246,7 @@ class WebsocketApp
   end
 
   def update_node_attributes(node_name, message)
-    node = FlightScheduler.app.default_partition.nodes.find do |n|
-      n.name == node_name
-    end
+    node = FlightScheduler.app.nodes[node_name]
     return unless node
 
     attributes = node.attributes.dup

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -36,6 +36,7 @@ module FlightScheduler
   autoload(:DaemonConnections, 'flight_scheduler/daemon_connections')
   autoload(:EventProcessor, 'flight_scheduler/event_processor')
   autoload(:JobRegistry, 'flight_scheduler/job_registry')
+  autoload(:NodeRegistry, 'flight_scheduler/node_registry')
   autoload(:PathGenerator, 'flight_scheduler/path_generator')
   autoload(:RangeExpander, 'flight_scheduler/range_expander')
   autoload(:Schedulers, 'flight_scheduler/schedulers')

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -36,6 +36,7 @@ module FlightScheduler
     attr_reader :daemon_connections
     attr_reader :job_registry
     attr_reader :schedulers
+    attr_reader :nodes
 
     def initialize(allocations:, daemon_connections:, job_registry:, schedulers:)
       @allocations = allocations
@@ -54,6 +55,10 @@ module FlightScheduler
 
     def partitions
       config.partitions
+    end
+
+    def nodes
+      config.nodes
     end
 
     def default_partition

--- a/lib/flight_scheduler/configuration.rb
+++ b/lib/flight_scheduler/configuration.rb
@@ -91,10 +91,14 @@ module FlightScheduler
       Async.logger.send("#{@log_level}!")
     end
 
+    def nodes
+      @nodes ||= NodeRegistry.new
+    end
+
     def partitions=(partition_specs)
       @partitions = partition_specs.map do |spec|
-        nodes = spec['nodes'].map { |node_name| Node.new(name: node_name) }
-        Partition.new(default: spec['default'], name: spec['name'], nodes: nodes)
+        partition_nodes = spec['nodes'].map { |node_name| nodes.fetch_or_add(node_name) }
+        Partition.new(default: spec['default'], name: spec['name'], nodes: partition_nodes)
       end
     end
   end

--- a/lib/flight_scheduler/node_registry.rb
+++ b/lib/flight_scheduler/node_registry.rb
@@ -1,0 +1,59 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+class FlightScheduler::NodeRegistry
+  def initialize
+    @nodes = {}
+    @mutex = Mutex.new
+  end
+
+  def fetch_or_add(node_name)
+    @mutex.synchronize do
+      if @nodes.key? node_name
+        @nodes[node_name]
+      else
+        @nodes[node_name] = Node.new(name: node_name)
+      end
+    end
+  end
+
+  def [](node_name)
+    with_lock { @nodes[node_name] }
+  end
+
+  private
+
+  def with_lock
+    if @mutex.owned?
+      yield
+    else
+      @mutex.synchronize do
+        yield
+      end
+    end
+  end
+end


### PR DESCRIPTION
The daemon now sends the profiled information as part of the `CONNECTED` message. This needs to be stored on the `Node` object.

Currently it is theoretically possible for a `node_name` to be in multiple partitions. However it is unclear whether these are indeed the same not or not. Dealing with this issue is out of scope of this PR, so instead only the default partition is considered.

The newly profiled information has been added to the serializer. 