### PR TITLE
Allow the client to set additional batch job environment variables

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -242,7 +242,7 @@ class App < Sinatra::Base
         property 'script-name', type: :string
         property 'stdout-path', type: :string, description: FlightScheduler::PathGenerator::DESC
         property 'stderr-path', type: :string, description: FlightScheduler::PathGenerator::DESC
-        property :envs, type: 'object', additionalProperties: {
+        property :environment,  type: 'object', additionalProperties: {
           type: 'string',
           description: 'Environment variables for batch jobs (including batch array jobs). Ignored for other job types'
         }
@@ -377,7 +377,7 @@ class App < Sinatra::Base
           stdout_path: attr[:stdout_path],
           # Use the original data hash as the keys have not been processed
           # NOTE: They do need type casting from symbols to keys
-          envs: data.fetch(:attributes, {}).fetch(:envs, {}).transform_keys(&:to_s)
+          env: data.fetch(:attributes, {}).fetch(:environment, {}).transform_keys(&:to_s)
         )
       end
       next job.id, job

--- a/app.rb
+++ b/app.rb
@@ -239,9 +239,13 @@ class App < Sinatra::Base
           end
         end
         property :script, type: :string
-        property 'script-name',  type: :string
+        property 'script-name', type: :string
         property 'stdout-path', type: :string, description: FlightScheduler::PathGenerator::DESC
         property 'stderr-path', type: :string, description: FlightScheduler::PathGenerator::DESC
+        property :envs, type: 'object', additionalProperties: {
+          type: 'string',
+          description: 'Environment variables for batch jobs (including batch array jobs). Ignored for other job types'
+        }
         property :arguments, type: :array do
           items type: :string
         end
@@ -265,7 +269,7 @@ class App < Sinatra::Base
       end
 
       operation :post do
-        key :summary, 'Create a new batch job'
+        key :summary, 'Create a new job'
         key :operationId, :createJob
         parameter do
           key :name, :data
@@ -361,7 +365,7 @@ class App < Sinatra::Base
         partition: FlightScheduler.app.default_partition,
         reason_pending: 'WaitingForScheduling',
         state: 'PENDING',
-        username: current_user,
+        username: current_user
       )
       if attr[:script] || attr[:arguments] || attr[:script_name]
         job.batch_script = BatchScript.new(
@@ -371,6 +375,9 @@ class App < Sinatra::Base
           name: attr[:script_name],
           stderr_path: attr[:stderr_path],
           stdout_path: attr[:stdout_path],
+          # Use the original data hash as the keys have not been processed
+          # NOTE: They do need type casting from symbols to keys
+          envs: data.fetch(:attributes, {}).fetch(:envs, {}).transform_keys(&:to_s)
         )
       end
       next job.id, job

--- a/app/models/batch_script.rb
+++ b/app/models/batch_script.rb
@@ -45,7 +45,7 @@ class BatchScript
   attr_accessor :content
   attr_accessor :job
   attr_accessor :name
-  attr_accessor :envs
+  attr_accessor :env
 
   attr_writer :stderr_path
   attr_writer :stdout_path
@@ -53,7 +53,7 @@ class BatchScript
   validates :content, presence: true
   validates :job, presence: true
   validates :name, presence: true
-  validate  :validate_envs_hash
+  validate  :validate_env_hash
 
   def stdout_path
     if @stdout_path.blank? && job.job_type == 'ARRAY_JOB'
@@ -95,16 +95,16 @@ class BatchScript
     File.join(FlightScheduler.app.config.spool_dir, 'jobs', job.id.to_s, 'job-script')
   end
 
-  def validate_envs_hash
-    if envs.is_a? Hash
-      unless envs.keys.all? { |k| k.is_a? String }
-        @errors.add(:envs, 'must have string keys')
+  def validate_env_hash
+    if env.is_a? Hash
+      unless env.keys.all? { |k| k.is_a? String }
+        @errors.add(:env, 'must have string keys')
       end
-      unless envs.values.all? { |k| k.is_a? String }
-        @errors.add(:envs, 'must have string values')
+      unless env.values.all? { |k| k.is_a? String }
+        @errors.add(:env, 'must have string values')
       end
     else
-      @errors.add(:envs, 'must be a hash')
+      @errors.add(:env, 'must be a hash')
     end
   end
 end

--- a/app/models/batch_script.rb
+++ b/app/models/batch_script.rb
@@ -45,6 +45,7 @@ class BatchScript
   attr_accessor :content
   attr_accessor :job
   attr_accessor :name
+  attr_accessor :envs
 
   attr_writer :stderr_path
   attr_writer :stdout_path
@@ -52,6 +53,7 @@ class BatchScript
   validates :content, presence: true
   validates :job, presence: true
   validates :name, presence: true
+  validate  :validate_envs_hash
 
   def stdout_path
     if @stdout_path.blank? && job.job_type == 'ARRAY_JOB'
@@ -91,5 +93,18 @@ class BatchScript
 
   def path
     File.join(FlightScheduler.app.config.spool_dir, 'jobs', job.id.to_s, 'job-script')
+  end
+
+  def validate_envs_hash
+    if envs.is_a? Hash
+      unless envs.keys.all? { |k| k.is_a? String }
+        @errors.add(:envs, 'must have string keys')
+      end
+      unless envs.values.all? { |k| k.is_a? String }
+        @errors.add(:envs, 'must have string values')
+      end
+    else
+      @errors.add(:envs, 'must be a hash')
+    end
   end
 end

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -46,7 +46,7 @@ module FlightScheduler::Submission
       #
       # TODO: Consider refactoring to make nodes a mandatory argument.
       allocated_nodes ||= (job.allocation&.nodes&.map(&:name) || [])
-      job.batch_script.envs.merge(
+      job.batch_script.env.merge(
         "#{prefix}CLUSTER_NAME"  => FlightScheduler.app.config.cluster_name.to_s,
         "#{prefix}JOB_ID"        => job.id,
         "#{prefix}JOB_NAME"      => (job.array_job || job).name,

--- a/lib/flight_scheduler/submission/env_generator.rb
+++ b/lib/flight_scheduler/submission/env_generator.rb
@@ -46,7 +46,7 @@ module FlightScheduler::Submission
       #
       # TODO: Consider refactoring to make nodes a mandatory argument.
       allocated_nodes ||= (job.allocation&.nodes&.map(&:name) || [])
-      {
+      job.batch_script.envs.merge(
         "#{prefix}CLUSTER_NAME"  => FlightScheduler.app.config.cluster_name.to_s,
         "#{prefix}JOB_ID"        => job.id,
         "#{prefix}JOB_NAME"      => (job.array_job || job).name,
@@ -54,7 +54,7 @@ module FlightScheduler::Submission
         "#{prefix}JOB_NODES"     => allocated_nodes.length.to_s, # Must be a string
         "#{prefix}JOB_NUM_NODES" => allocated_nodes.length.to_s, # Must be a string
         "#{prefix}JOB_NODELIST"  => allocated_nodes.join(','),
-      }
+      )
     end
     module_function :for_shared
 


### PR DESCRIPTION
The client now submits an `envs` hash of environment variables with batch jobs. These are included in the existing environment hash which is sent to the daemon. No change is required in the daemon