### PR TITLE
Job persistence

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -177,6 +177,7 @@ class App < Sinatra::Base
 
       def validate!
         if @created && resource.validate!
+          resource.write
           resource.job.job_steps << resource
           FlightScheduler.app.event_processor.job_step_created(resource)
         end

--- a/app/models/batch_script.rb
+++ b/app/models/batch_script.rb
@@ -87,9 +87,7 @@ class BatchScript
 
   # Must be called at the end of the job lifecycle to remove the script
   def cleanup
-    Async::IO::Threads.new.async do
-      FileUtils.rm_rf(File.dirname(script_path))
-    end.wait
+    Async::IO::Threads.new.async { FileUtils.rm_rf(dirname) }.wait
   end
 
   def write

--- a/app/models/batch_script.rb
+++ b/app/models/batch_script.rb
@@ -37,6 +37,7 @@ require 'async/io/threads'
 #
 class BatchScript
   include ActiveModel::Model
+  include ActiveModel::Serialization
 
   DEFAULT_PATH = 'flight-scheduler-%j.out'
   ARRAY_DEFAULT_PATH = 'flight-scheduler-%A_%a.out'
@@ -67,6 +68,12 @@ class BatchScript
 
   def stderr_path
     @stderr_path.blank? ? stdout_path : @stderr_path
+  end
+
+  def attributes
+    {
+      arguments: nil, name: nil, stdout_path: nil, stderr_path: nil,
+    }
   end
 
   # Must be called at the end of the job lifecycle to remove the script

--- a/app/models/batch_script.rb
+++ b/app/models/batch_script.rb
@@ -87,7 +87,11 @@ class BatchScript
 
   # Must be called at the end of the job lifecycle to remove the script
   def cleanup
-    Async::IO::Threads.new.async { FileUtils.rm_rf(dirname) }.wait
+    if Async::Task.current?
+      Async::IO::Threads.new.async { FileUtils.rm_rf(dirname) }.wait
+    else
+      FileUtils.rm_rf(dirname)
+    end
   end
 
   def write

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -249,9 +249,7 @@ class Job
         )
       end
       if hash['next_array_index'] && job.task_generator
-        while job.task_generator.next_index != hash['next_array_index']
-          job.task_generator.advance_next_task
-        end
+        job.task_generator.next_index = hash['next_array_index']
       end
       if hash['job_steps']
         job.job_steps = hash['job_steps'].map do |h|

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -265,6 +265,7 @@ class Job
 
   # Must be called at the end of the job lifecycle.
   def cleanup
+    job_steps.each(&:cleanup)
     if has_batch_script? && !job_type == 'ARRAY_TASK'
       batch_script.cleanup
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -266,7 +266,7 @@ class Job
   # Must be called at the end of the job lifecycle.
   def cleanup
     job_steps.each(&:cleanup)
-    if has_batch_script? && !job_type == 'ARRAY_TASK'
+    if has_batch_script? && job_type != 'ARRAY_TASK'
       batch_script.cleanup
     end
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -264,8 +264,14 @@ class Job
     end
   end
 
-  def allocated?
-    allocation ? true : false
+  def allocated?(include_tasks: false)
+    if allocation
+      true
+    elsif include_tasks && job_type == 'ARRAY_JOB'
+      FlightScheduler.app.job_registry.tasks_for(self).any?(&:allocated?)
+    else
+      false
+    end
   end
 
   def allocation

--- a/app/models/job_step.rb
+++ b/app/models/job_step.rb
@@ -121,12 +121,14 @@ class JobStep
   end
 
   def write
+    # We only write the environment once, when the step is first created.
+    return if @env.nil?
     Async::IO::Threads.new.async do
       FileUtils.mkdir_p(dirname)
       serialized_env = env.map { |k, v| "#{k}=#{v}" }.join("\0")
       File.write(env_path, serialized_env)
       # We don't want the env hanging around in memory.
-      self.env = nil
+      @env = nil
     end.wait
   end
 

--- a/app/models/job_step.rb
+++ b/app/models/job_step.rb
@@ -51,13 +51,7 @@ class JobStep
   validate  :validate_env_is_a_hash
 
   def self.from_serialized_hash(hash)
-    new(
-      arguments: hash['arguments'],
-      id: hash['id'],
-      job: hash['job'],
-      path: hash['path'],
-      pty: hash['pty'],
-    ).tap do |step|
+    new(**hash.stringify_keys.slice(*%w(arguments id job path pty))).tap do |step|
       step.executions = hash['executions'].map do |h|
         Execution.from_serialized_hash(h.merge(job_step: step))
       end
@@ -65,6 +59,7 @@ class JobStep
   end
 
   def initialize(params={})
+    self.env = {}
     super
     self.executions ||= []
   end
@@ -134,12 +129,7 @@ class JobStep
       inclusion: { within: STATES }
 
     def self.from_serialized_hash(hash)
-      new(
-        id: hash['id'],
-        job_step: hash['job_step'],
-        node_name: hash['node_name'],
-        state: hash['state'],
-      )
+      new(**hash.stringify_keys.slice(*%w(id job_step node_name port state)))
     end
 
     def attributes

--- a/app/models/job_step.rb
+++ b/app/models/job_step.rb
@@ -50,6 +50,20 @@ class JobStep
   validates :path, presence: true
   validate  :validate_env_is_a_hash
 
+  def self.from_serialized_hash(hash)
+    new(
+      arguments: hash['arguments'],
+      id: hash['id'],
+      job: hash['job'],
+      path: hash['path'],
+      pty: hash['pty'],
+    ).tap do |step|
+      step.executions = hash['executions'].map do |h|
+        Execution.from_serialized_hash(h.merge(job_step: step))
+      end
+    end
+  end
+
   def initialize(params={})
     super
     self.executions ||= []
@@ -118,6 +132,15 @@ class JobStep
     validates :state,
       presence: true,
       inclusion: { within: STATES }
+
+    def self.from_serialized_hash(hash)
+      new(
+        id: hash['id'],
+        job_step: hash['job_step'],
+        node_name: hash['node_name'],
+        state: hash['state'],
+      )
+    end
 
     def attributes
       { id: nil, node_name: nil, port: nil, state: nil}

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -215,7 +215,7 @@ class JobStep::ExecutionSerializer < BaseSerializer
   # NOTE: The idiomatic approach would be to specify the `node` as a has_one
   #       relationship. Not doing so prevents the node data from being sideloaded
   #       by the client
-  attribute(:node) { object.node.name }
+  attribute(:node) { object.node_name }
   attribute :port
   attribute :state
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -39,5 +39,6 @@ require_relative '../app/models/job'
 require_relative '../app/models/job_step'
 
 unless FlightScheduler.env.test?
+  FlightScheduler.app.job_registry.load
   FlightScheduler.app.init_periodic_processor
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -40,5 +40,6 @@ require_relative '../app/models/job_step'
 
 unless FlightScheduler.env.test?
   FlightScheduler.app.job_registry.load
+  FlightScheduler.app.allocations.load
   FlightScheduler.app.init_periodic_processor
 end

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -39,6 +39,7 @@ module FlightScheduler
   autoload(:LoadBalancer, 'flight_scheduler/load_balancer')
   autoload(:NodeRegistry, 'flight_scheduler/node_registry')
   autoload(:PathGenerator, 'flight_scheduler/path_generator')
+  autoload(:Persistence, 'flight_scheduler/persistence')
   autoload(:RangeExpander, 'flight_scheduler/range_expander')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
 

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -86,6 +86,7 @@ module FlightScheduler
             Async.logger.debug("Running periodic processor")
             job_registry.remove_old_jobs
             job_registry.save
+            allocations.save
             Async.logger.debug("Done running periodic processor")
           end
           timer.execute

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -88,6 +88,7 @@ module FlightScheduler
             Async.logger.debug("Done running periodic processor")
           end
           timer.execute
+          timer
         end
     end
   end

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -85,6 +85,7 @@ module FlightScheduler
           timer = Concurrent::TimerTask.new(**opts) do
             Async.logger.debug("Running periodic processor")
             job_registry.remove_old_jobs
+            job_registry.save
             Async.logger.debug("Done running periodic processor")
           end
           timer.execute

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -87,7 +87,7 @@ module FlightScheduler
             job_registry.remove_old_jobs
             job_registry.save
             job_registry.jobs_in_state(Job::TERMINAL_STATES).each do |job|
-              Async.logger.info("Removing allocation for job in terminal state: id=#{job.display_id} state=#{job.state}")
+              Async.logger.debug("Removing allocation for job in terminal state: id=#{job.display_id} state=#{job.state}")
               FlightScheduler::Deallocation::Job.new(job).call
             end
             allocations.save

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -86,6 +86,10 @@ module FlightScheduler
             Async.logger.debug("Running periodic processor")
             job_registry.remove_old_jobs
             job_registry.save
+            job_registry.jobs_in_state(Job::TERMINAL_STATES).each do |job|
+              Async.logger.info("Removing allocation for job in terminal state: id=#{job.display_id} state=#{job.state}")
+              FlightScheduler::Deallocation::Job.new(job).call
+            end
             allocations.save
             Async.logger.debug("Done running periodic processor")
           end

--- a/lib/flight_scheduler/array_task_generator.rb
+++ b/lib/flight_scheduler/array_task_generator.rb
@@ -35,22 +35,32 @@
 #
 # `advance_next_task`: advances the ARRAY_TASK returned by `next_task`.
 class FlightScheduler::ArrayTaskGenerator
-  attr_reader :next_task
-
   def initialize(job)
     @job = job
     @array_range = job.array_range.expanded
     @index_into_array_range = 0
-    @next_task = build_next_task
   end
 
   def advance_next_task
     @index_into_array_range += 1
-    @next_task = build_next_task
   end
 
   def next_index
     @array_range[@index_into_array_range]
+  end
+
+  def next_index=(array_index)
+    @index_into_array_range = @array_range.find_index(array_index)
+  end
+
+  def next_task
+    if finished?
+      nil
+    elsif !@next_task.nil? && @next_task.array_index == next_index
+      @next_task
+    else
+      @next_task = build_next_task
+    end
   end
 
   def finished?

--- a/lib/flight_scheduler/deallocation/job.rb
+++ b/lib/flight_scheduler/deallocation/job.rb
@@ -35,6 +35,8 @@ module FlightScheduler::Deallocation
     def call
       allocation = FlightScheduler.app.allocations.for_job(@job.id)
 
+      return if allocation.nil?
+
       # Notify all nodes the job has finished
       allocation.nodes.each do |target_node|
         connection = FlightScheduler.app.daemon_connections.connection_for(target_node.name)

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -122,13 +122,13 @@ module FlightScheduler::EventProcessor
     return unless allocation
     job = allocation.job
 
-    if allocation.nodes.empty? && !job.has_batch_script? && !job.terminal_state?
-      # If the job does not have a batch script, i.e., it was created with the
-      # `alloc` command, we need to update it to a terminal state here.  If it
-      # has a batch script it will be updated when the
-      # `NODE_{COMPLETED,FAILED}_JOB` command is received.  Ideally, we'd
-      # capture the exit code of some command somewhere to be able to set the
-      # FAILED state if appropriate.
+    if allocation.nodes.empty? && !job.terminal_state?
+      # If the job is not in a terminal state, it has not been updated
+      # following a `NODE_{COMPLETED,FAILED}_JOB` command.  It might have been
+      # created without a batch script, i.e., created with the `alloc`
+      # command.  Or the message might not have been sent or received.
+      # Ideally, we'd capture the exit code of some command somewhere to be
+      # able to set the FAILED state if appropriate.
       if job.state == 'CANCELLING'
         job.state = 'CANCELLED'
       else

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -86,6 +86,7 @@ module FlightScheduler::EventProcessor
       FlightScheduler::Submission::Job.new(allocation).call
     end
     FlightScheduler.app.job_registry.save
+    FlightScheduler.app.allocations.save
   end
   module_function :allocate_resources_and_run_jobs
 

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -70,7 +70,11 @@ module FlightScheduler::EventProcessor
       end.join("\n")
     }
     Async.logger.debug("Allocated nodes") {
-      allocated_nodes = FlightScheduler.app.allocations.each.map { |a| a.nodes }.flatten.sort.uniq
+      allocated_nodes = FlightScheduler.app.allocations.each
+        .map { |a| a.nodes }
+        .flatten
+        .sort_by(&:name)
+        .uniq
       if allocated_nodes.empty?
         "None"
       else

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -196,7 +196,7 @@ module FlightScheduler::EventProcessor
       Async.logger.info("Cancelling pending job #{job.display_id}")
       job.state = 'CANCELLED'
       allocate_resources_and_run_jobs
-    when 'RUNNING'
+    when 'RUNNING', 'CANCELLING'
       Async.logger.info("Cancelling running job #{job.display_id}")
       FlightScheduler::Cancellation::Job.new(job).call
     else

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -85,6 +85,7 @@ module FlightScheduler::EventProcessor
       Async.logger.info("Allocated #{allocated_node_names} to job #{allocation.job.display_id}")
       FlightScheduler::Submission::Job.new(allocation).call
     end
+    FlightScheduler.app.job_registry.save
   end
   module_function :allocate_resources_and_run_jobs
 
@@ -142,8 +143,9 @@ module FlightScheduler::EventProcessor
     job_step = job.job_steps.detect { |step| step.id == step_id }
     Async.logger.info("Node #{node_name} started step #{job_step.display_id}")
     execution = job_step.execution_for(node_name)
-    execution.state = 'STARTED'
+    execution.state = 'RUNNING'
     execution.port = port
+    FlightScheduler.app.job_registry.save
   end
   module_function :job_step_started
 
@@ -153,6 +155,7 @@ module FlightScheduler::EventProcessor
     Async.logger.info("Node #{node_name} completed step #{job_step.display_id}")
     execution = job_step.execution_for(node_name)
     execution.state = 'COMPLETED'
+    FlightScheduler.app.job_registry.save
   end
   module_function :job_step_completed
 
@@ -162,6 +165,7 @@ module FlightScheduler::EventProcessor
     Async.logger.info("Node #{node_name} failed step #{job_step.display_id}")
     execution = job_step.execution_for(node_name)
     execution.state = 'FAILED'
+    FlightScheduler.app.job_registry.save
   end
   module_function :job_step_failed
 

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -77,7 +77,7 @@ class FlightScheduler::JobRegistry
             Async.logger.debug("Removed job:#{job.display_id} from job registry")
           end
         rescue
-          Async.logger.warn("Failed processing potentially old job:#{job.display_id}")
+          Async.logger.warn("Failed processing potentially old job:#{job.display_id}") { $! }
         end
       end
     end

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -70,7 +70,7 @@ class FlightScheduler::JobRegistry
         begin
           # Its possible that we're still processing the request to deallocate
           # the job.  If that's the case, we'll clean this job up another time.
-          if job.allocated?
+          if job.allocated? || FlightScheduler.app.job_registry.tasks_for(job).any?(&:allocated?)
             Async.logger.debug("Skipping job:#{job.display_id} due to existing allocation")
           else
             delete(job)

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -70,7 +70,7 @@ class FlightScheduler::JobRegistry
         begin
           # Its possible that we're still processing the request to deallocate
           # the job.  If that's the case, we'll clean this job up another time.
-          if job.allocated? || FlightScheduler.app.job_registry.tasks_for(job).any?(&:allocated?)
+          if job.allocated?
             Async.logger.debug("Skipping job:#{job.display_id} due to existing allocation")
           else
             delete(job)

--- a/lib/flight_scheduler/persistence.rb
+++ b/lib/flight_scheduler/persistence.rb
@@ -1,0 +1,100 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+class FlightScheduler::Persistence
+  def initialize(registry_name, filename)
+    @registry_name = registry_name
+    @path = File.join(FlightScheduler.app.config.spool_dir, filename)
+    @old_path = File.join(FlightScheduler.app.config.spool_dir, "#{filename}.old")
+  end
+
+  def load
+    unless File.exist?(@path) || File.exist?(@old_path)
+      Async.logger.info("No saved data for #{@registry_name}")
+      return nil 
+    end
+    failed = false
+    path = failed ? @old_path : @path
+    begin
+      Async.logger.info("Loading #{@registry_name} from #{path}")
+      data = JSON.load(File.open(path))
+      Async.logger.debug("Loaded data") { data }
+      data
+    rescue
+      if failed
+        raise
+      else
+        failed = true
+        retry
+      end
+    end
+  rescue
+    Async.logger.warn("Error loading #{@registry_name}: #{$!.message}")
+    raise
+  end
+
+  def save(data)
+    Async.logger.info("Saving #{@registry_name}")
+    Async.logger.debug("Serializable data") { data }
+
+    block = lambda do
+      # We jump through some hoops to make writing the save state atomic and
+      # consistent.
+      #
+      # 1. Create a copy of the original state, by creating a hard-link to it.
+      # 2. Create a tempfile, being careful to make sure we create one that
+      #    isn't automatically removed.
+      # 3. Write the content to the tempfile.
+      # 4. If all the content is written, move the tempfile to the correct
+      #    path.
+      FileUtils.mkdir_p(File.dirname(@path))
+      if File.exist?(@path) && !FlightScheduler.env.test?
+        FileUtils.cp_lr(@path, @old_path, remove_destination: true)
+      end
+      begin
+        tmpfile = Tempfile.create(File.basename(@path), File.dirname(@path))
+        content = data.to_json
+        if tmpfile.write(content) == content.length
+          FileUtils.mv(tmpfile.path, @path)
+        end
+      ensure
+        tmpfile.close
+      end
+    end
+
+    if Async::Task.current?
+      Async::IO::Threads.new.async do
+        block.call
+      end.wait
+    else
+      block.call
+    end
+  rescue
+    Async.logger.warn("Error saving #{@registry_name}: #{$!.message}")
+    raise
+  end
+end

--- a/lib/flight_scheduler/range_expander.rb
+++ b/lib/flight_scheduler/range_expander.rb
@@ -37,12 +37,9 @@ module FlightScheduler
 
     attr_reader :parts
 
-    def self.split(range)
-      new(range.split(','))
-    end
-
-    def initialize(parts)
-      @parts = parts.map { |p| p.strip }
+    def initialize(array_spec)
+      @array_spec = array_spec
+      @parts = @array_spec.split(',').map { |p| p.strip }
     end
 
     def valid?
@@ -64,6 +61,10 @@ module FlightScheduler
 
     def expanded
       @expanded ||= expand.sort
+    end
+
+    def compressed
+      @array_spec
     end
 
     private

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe '/jobs', type: :controller do
       end
 
       it 'writes the script to disk' do
-        expect(File.read response_job.batch_script.path).to eq(script)
+        expect(File.read response_job.batch_script.send(:script_path)).to eq(script)
       end
 
       describe 'DELETE /{id}' do

--- a/spec/range_expander_spec.rb
+++ b/spec/range_expander_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FlightScheduler::RangeExpander do
   let(:range) { raise NotImplementedError }
   let(:expected) { raise NotImplementedError }
 
-  subject { described_class.split(range) }
+  subject { described_class.new(range) }
 
   shared_examples 'expands-range' do
     it { should be_valid }

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -415,6 +415,15 @@ RSpec.describe FifoScheduler, type: :scheduler do
 
       context 'after completing and removing the allocated ARRAY_JOB' do
         before do
+          job_registry.tasks_for(job).each do |task|
+            task.state = 'COMPLETED'
+            allocation = FlightScheduler.app.allocations.for_job(task)
+            if allocation
+              allocation.nodes.each do |node|
+                FlightScheduler.app.allocations.deallocate_node_from_job(task.id, node.name)
+              end
+            end
+          end
           job.state = 'COMPLETED'
           job_registry.remove_old_jobs
         end


### PR DESCRIPTION
This PR adds persistence of the job registry and allocations registry to the controller.

`Allocation` and `Job` instances have learned how to serialize themselves and the classes have learned how to create new instances from those serializations.

A new class `Persistence` has been developed which saves and the serializations it is given and loads the serializations from the save file.  The save routines have been written to ensure that saving either the `JobRegistry` or `AllocationRegistry` is atomic.  This guarantee is the primary reason why the *registry* is saved rather than the individual jobs or allocations.

Various events in `EventProcessor` have been adjusted to save the registries when they are likely to have changed.

The `Allocation` class has changed so that it no longer has a reference to `Node`s, but rather stores the node name and then looks up the node from the `NodeRegistry`.  This makes (de)serialising an allocation simpler.

The environment for batch scripts and job steps are stored along side the job script.  The format is a set of `key=value` pairs separated by null chars.  Null chars have been chosen to allow the values to contain new lines.

Much of the serialization code could probably been cleaned up by using `ActiveModel::Attributes` or `ActiveModel::AttributeMethods`.  This has been left for a future task.

When the controller starts, prior to the Rack app being initialized, the job registry and allocation registry are loaded from disk.  Only once, this is complete does the Rack app start.  This results in the load being in a different thread/fibre than the main `Async` loop.  It turns out that `Enumerator`s do not support being called from different fibres/threads, the raise an exception if this is done.

To work around this, `Enumerator` has been removed from `ArrayTaskGenerator` and replaced with an integer index into the array job's array range.
