### PR TITLE
Implement time limits for jobs and parititons

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -243,6 +243,7 @@ class App < Sinatra::Base
         property 'script-name', type: :string
         property 'stdout-path', type: :string, description: FlightScheduler::PathGenerator::DESC
         property 'stderr-path', type: :string, description: FlightScheduler::PathGenerator::DESC
+        property 'time-limit-spec', type: :string
         property :environment,  type: 'object', additionalProperties: {
           type: 'string',
           description: 'Environment variables for batch jobs (including batch array jobs). Ignored for other job types'
@@ -367,7 +368,7 @@ class App < Sinatra::Base
         reason_pending: 'WaitingForScheduling',
         state: 'PENDING',
         username: current_user,
-        **attr.slice(:cpus_per_node, :gpus_per_node, :memory_per_node, :exclusive)
+        **attr.slice(:cpus_per_node, :gpus_per_node, :memory_per_node, :exclusive, :time_limit_spec)
       )
       if attr[:script] || attr[:arguments] || attr[:script_name]
         job.batch_script = BatchScript.new(

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -344,7 +344,10 @@ class Job
 
   def time_limit
     if time_limit_spec
-      FlightScheduler::TimeResolver.new(time_limit_spec).resolve
+      int = FlightScheduler::TimeResolver.new(time_limit_spec).resolve
+      # Hide time limit's of zero meaning indefinite as it is counter intuitive
+      # It is solely used as syntax sugar for the client
+      int == 0 ? nil : int
     else
       partition.default_time_limit
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -70,7 +70,7 @@ class Job
       end
 
     # Attributes copied directly from the persisted state.
-    attr_names = %w(array array_index id job_type min_nodes reason_pending state username)
+    attr_names = %w(array array_index id job_type min_nodes reason_pending state username time_limit_spec)
     attrs = hash.stringify_keys.slice(*attr_names)
 
     new(array_job: array_job, partition: partition, **attrs).tap do |job|
@@ -231,6 +231,7 @@ class Job
       min_nodes: nil,
       reason_pending: nil,
       state: nil,
+      time_limit_spec: nil,
       username: nil,
     }
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -334,6 +334,10 @@ class Job
     has_batch_script? ? batch_script.env : {}
   end
 
+  def time_limit
+    partition.default_time_limit
+  end
+
   protected
 
   def update_array_job_state

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -48,10 +48,10 @@ class Job
   include ActiveModel::Serialization
 
   PENDING_REASONS = %w( WaitingForScheduling Priority Resources ).freeze
-  STATES = %w( PENDING RUNNING CANCELLING CANCELLED COMPLETED FAILED ).freeze
+  STATES = %w( PENDING RUNNING CANCELLING CANCELLED COMPLETED FAILED TIMINGOUT TIMEOUT ).freeze
   # NOTE: If adding new states to TERMINAL_STATES, `update_array_job_state`
   # will need updating too.
-  TERMINAL_STATES = %w( CANCELLED COMPLETED FAILED ).freeze
+  TERMINAL_STATES = %w( CANCELLED COMPLETED FAILED TIMEOUT ).freeze
   STATES.each do |s|
     define_method("#{s.downcase}?") { self.state == s }
   end
@@ -351,6 +351,8 @@ class Job
       self.state = 'FAILED'
     elsif tasks.any? { |t| t.state == 'CANCELLED' }
       self.state = 'CANCELLED'
+    elsif tasks.any? { |t| t.state == 'TIMEOUT' }
+      self.state = 'TIMEOUT'
     else
       # They must all be completed then.
       self.state = 'COMPLETED'

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -26,13 +26,15 @@
 #==============================================================================
 
 class Partition
-  attr_reader :name, :nodes, :time_limit
+  attr_reader :name, :nodes, :max_time_limit, :default_time_limit
 
-  def initialize(name:, nodes:, default: false, time_limit: nil)
+  def initialize(name:, nodes:, default: false,
+                 max_time_limit: nil, default_time_limit: nil)
     @name = name
     @nodes = nodes
     @default = default
-    @time_limit = FlightScheduler::TimeResolver.new(time_limit).resolve
+    @max_time_limit = max_time_limit
+    @default_time_limit = default_time_limit
   end
 
   def default?

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -26,12 +26,13 @@
 #==============================================================================
 
 class Partition
-  attr_reader :name, :nodes
+  attr_reader :name, :nodes, :time_limit
 
-  def initialize(name:, nodes:, default: false)
+  def initialize(name:, nodes:, default: false, time_limit: nil)
     @name = name
     @nodes = nodes
     @default = default
+    @time_limit = FlightScheduler::TimeResolver.new(time_limit).resolve
   end
 
   def default?

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -120,6 +120,7 @@ class JobSerializer < BaseSerializer
       property 'script-name', type: :string
       property :reason, type: :string, enum: Job::PENDING_REASONS, nullable: true
       property :username
+      property :time_limit, type: :integer, nullable: true
     end
     property :relationships do
       property :partition do
@@ -152,6 +153,7 @@ class JobSerializer < BaseSerializer
   attribute(:script_name) { ( object.array_job || object ).batch_script&.name }
   attribute(:reason) { object.reason_pending }
   attribute :username
+  attribute :time_limit
 
   has_one :partition
   has_many(:allocated_nodes) { (object.allocation&.nodes || []) }

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -46,6 +46,7 @@ class PartitionSerializer < BaseSerializer
     property :type, type: :string, enum: ['partitions']
     property :attributes do
       property :name, type: :string
+      property :time_limit, type: :integer
       property :nodes, type: :array do
         items { key :type, :string }
       end
@@ -67,7 +68,7 @@ class PartitionSerializer < BaseSerializer
   def id
     object.name
   end
-  attribute :name
+  attributes :name, :time_limit
 
   has_many(:nodes) { object.nodes }
 end

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -46,7 +46,8 @@ class PartitionSerializer < BaseSerializer
     property :type, type: :string, enum: ['partitions']
     property :attributes do
       property :name, type: :string
-      property :time_limit, type: :integer
+      property :max_time_limit, type: :integer
+      property :default_time_limit, type: :integer
       property :nodes, type: :array do
         items { key :type, :string }
       end
@@ -68,7 +69,7 @@ class PartitionSerializer < BaseSerializer
   def id
     object.name
   end
-  attributes :name, :time_limit
+  attributes :name, :max_time_limit, :default_time_limit
 
   has_many(:nodes) { object.nodes }
 end

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -162,6 +162,7 @@ class WebsocketApp
     property :command, type: :string, required: true, enum: ['JOB_ALLOCATED']
     property :job_id, type: :string, required: true
     property :username, type: :string, required: true
+    property :time_limit, type: :integer, require: false
 
     prefix = FlightScheduler.app.config.env_var_prefix
     property :environment, required: true do

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -69,6 +69,10 @@ class MessageProcessor
       step_id = message[:step_id]
       FlightScheduler.app.event_processor.job_step_failed(@node_name, job_id, step_id)
 
+    when 'JOB_TIMED_OUT'
+      job_id = message[:job_id]
+      FlightScheduler.app.event_processor.job_timed_out(job_id)
+
     else
       Async.logger.info("Unknown message #{message}")
     end
@@ -200,6 +204,11 @@ class WebsocketApp
     property :job_id, type: :string, required: true
   end
 
+  swagger_schema 'jobTimedOut' do
+    property :command, type: :string, required: true, enum: ['JOB_TIMED_OUT']
+    property :job_id, type: :string, required: true
+  end
+
   swagger_path '/ws' do
     operation :get do
       key :summary, 'Establish a control-daemon connection'
@@ -242,6 +251,9 @@ class WebsocketApp
       end
       response 'JOB_DEALLOCATED' do
         schema { key :'$ref', :jobDeallocatedWS }
+      end
+      response 'JOB_TIMED_OUT' do
+        schema { key :'$ref', :jobTimedOut }
       end
     end
   end

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -82,7 +82,7 @@ partitions:
   - name: all
     default: true
     max_time_limit:     10
-    default_time_limit: 5
+    default_time_limit: "0:5"
     nodes:
       - node01
       - node02

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -81,8 +81,8 @@
 partitions:
   - name: all
     default: true
-    max_time_limit:     10
-    default_time_limit: "0:5"
+    max_time_limit: 10
+    default_time_limit: 1
     nodes:
       - node01
       - node02

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -81,6 +81,7 @@
 partitions:
   - name: all
     default: true
+    time_limit: 5
     nodes:
       - node01
       - node02

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -81,7 +81,8 @@
 partitions:
   - name: all
     default: true
-    time_limit: 5
+    max_time_limit:     10
+    default_time_limit: 5
     nodes:
       - node01
       - node02

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -42,6 +42,7 @@ module FlightScheduler
   autoload(:Persistence, 'flight_scheduler/persistence')
   autoload(:RangeExpander, 'flight_scheduler/range_expander')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
+  autoload(:TimeResolver, 'flight_scheduler/time_resolver')
 
   module Cancellation
     autoload(:ArrayJob, 'flight_scheduler/cancellation/array_job')

--- a/lib/flight_scheduler/configuration.rb
+++ b/lib/flight_scheduler/configuration.rb
@@ -103,7 +103,7 @@ module FlightScheduler
     def partitions=(partition_specs)
       @partitions = partition_specs.map do |spec|
         partition_nodes = spec['nodes'].map { |node_name| nodes.fetch_or_add(node_name) }
-        Partition.new(default: spec['default'], name: spec['name'], nodes: partition_nodes)
+        Partition.new(default: spec['default'], name: spec['name'], nodes: partition_nodes, time_limit: spec['time_limit'])
       end
     end
   end

--- a/lib/flight_scheduler/configuration.rb
+++ b/lib/flight_scheduler/configuration.rb
@@ -31,6 +31,8 @@ require_relative '../../app/models/partition'
 
 module FlightScheduler
   class Configuration
+    class ConfigError < RuntimeError; end
+
     autoload(:Loader, 'flight_scheduler/configuration/loader')
 
     ATTRIBUTES = [
@@ -103,7 +105,45 @@ module FlightScheduler
     def partitions=(partition_specs)
       @partitions = partition_specs.map do |spec|
         partition_nodes = spec['nodes'].map { |node_name| nodes.fetch_or_add(node_name) }
-        Partition.new(default: spec['default'], name: spec['name'], nodes: partition_nodes, time_limit: spec['time_limit'])
+        max, default = parse_times(spec['max_time_limit'], spec['default_time_limit'], name: spec['name'])
+        Partition.new(
+          default: spec['default'], name: spec['name'], nodes: partition_nodes,
+          max_time_limit: max, default_time_limit: default
+        )
+      end
+    end
+
+    private
+
+    def parse_times(max, default, name:)
+      if max && default
+        t_max = TimeResolver.new(max).resolve
+        t_default = TimeResolver.new(default).resolve
+        if t_max.nil?
+          raise ConfigError, "Partition '#{name}': could not parse max time limit: #{max}"
+        elsif t_default.nil?
+          raise ConfigError, "Partition '#{name}': could not parse default time limit: #{default}"
+        elsif t_default > t_max
+          raise ConfigError, "Partiitio '#{name}': the default time limit must be less than the maximum"
+        else
+          [t_max, t_default]
+        end
+      elsif max
+        t_max = TimeResolver.new(max).resolve
+        if t_max.nil?
+          raise ConfigError, "Partition '#{name}': could not parse max time limit: #{max}"
+        else
+          [t_max, t_max]
+        end
+      elsif default
+        t_default = TimeResolver.new(default).resolve
+        if t_default.nil?
+          raise ConfigError, "Partition '#{name}': could not parse default time limit: #{default}"
+        else
+          [nil, t_default]
+        end
+      else
+        [nil, nil]
       end
     end
   end

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -99,7 +99,13 @@ module FlightScheduler::EventProcessor
     return if job.nil?
 
     Async.logger.info("Node #{node_name} completed job #{job.display_id}")
-    job.state = 'COMPLETED'
+    if job.state == 'CANCELLING'
+      job.state = 'CANCELLED'
+    elsif job.state == 'TIMINGOUT'
+      job.state = 'TIMEOUT'
+    else
+      job.state = 'COMPLETED'
+    end
     FlightScheduler::Deallocation::Job.new(job).call
   end
   module_function :node_completed_job
@@ -111,6 +117,8 @@ module FlightScheduler::EventProcessor
     Async.logger.info("Node #{node_name} failed job #{job.display_id}")
     if job.state == 'CANCELLING'
       job.state = 'CANCELLED'
+    elsif job.state == 'TIMINGOUT'
+      job.state = 'TIMEOUT'
     else
       job.state = 'FAILED'
     end
@@ -135,6 +143,8 @@ module FlightScheduler::EventProcessor
       # able to set the FAILED state if appropriate.
       if job.state == 'CANCELLING'
         job.state = 'CANCELLED'
+      elsif job.state == 'TIMINGOUT'
+        job.state = 'TIMEOUT'
       else
         job.state = 'COMPLETED'
       end
@@ -185,6 +195,13 @@ module FlightScheduler::EventProcessor
     end
   end
   module_function :cancel_job
+
+  def job_timed_out(job_id)
+    job = FlightScheduler.app.job_registry.lookup(job_id)
+    return unless job
+    job.state = job.terminal_state? ? 'TIMEOUT' : 'TIMINGOUT'
+  end
+  module_function :job_timed_out
 
   # TODO: Which one is required for module_function?
   private

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -99,13 +99,7 @@ module FlightScheduler::EventProcessor
     return if job.nil?
 
     Async.logger.info("Node #{node_name} completed job #{job.display_id}")
-    if job.state == 'CANCELLING'
-      job.state = 'CANCELLED'
-    elsif job.state == 'TIMINGOUT'
-      job.state = 'TIMEOUT'
-    else
-      job.state = 'COMPLETED'
-    end
+    job.state = 'COMPLETED'
     FlightScheduler::Deallocation::Job.new(job).call
   end
   module_function :node_completed_job

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -60,7 +60,7 @@ class FifoScheduler
             job
           end
 
-          unless (max = job.partition.max_time_limit).nil?
+          if max = job.partition.max_time_limit
             if job.time_limit.nil? || job.time_limit > max
               job.reason_pending = 'PartitionTimeLimit'
               next

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -54,17 +54,14 @@ class FifoScheduler
         candidate = queue.reduce(nil) do |memo, job|
           break memo if memo
           next unless job.pending? && job.allocation.nil?
+          max_time_limit = job.partition.max_time_limit
+          if max_time_limit && job.time_limit.nil? || job.time_limit > max_time_limit
+            job.reason_pending = 'PartitionTimeLimit'
+            next
+          end
           if job.job_type == 'ARRAY_JOB'
             job.task_generator.next_task
           else
-            job
-          end
-
-          if max = job.partition.max_time_limit
-            if job.time_limit.nil? || job.time_limit > max
-              job.reason_pending = 'PartitionTimeLimit'
-              next
-            end
             job
           end
         end

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -59,6 +59,14 @@ class FifoScheduler
           else
             job
           end
+
+          unless [0, nil].include?(max = job.partition.max_time_limit)
+            if job.time_limit == 0 || job.time_limit > max
+              job.reason_pending = 'PartitionTimeLimit'
+              next
+            end
+            job
+          end
         end
 
         break if candidate.nil?

--- a/lib/flight_scheduler/schedulers/fifo_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/fifo_scheduler.rb
@@ -60,8 +60,8 @@ class FifoScheduler
             job
           end
 
-          unless [0, nil].include?(max = job.partition.max_time_limit)
-            if job.time_limit == 0 || job.time_limit > max
+          unless (max = job.partition.max_time_limit).nil?
+            if job.time_limit.nil? || job.time_limit > max
               job.reason_pending = 'PartitionTimeLimit'
               next
             end

--- a/lib/flight_scheduler/submission/job.rb
+++ b/lib/flight_scheduler/submission/job.rb
@@ -66,6 +66,7 @@ module FlightScheduler::Submission
         environment: EnvGenerator.call(node, @job),
         job_id: @job.id,
         username: @job.username,
+        time_limit: @job.time_limit
       })
       connection.flush
       Async.logger.debug("Initialized job #{@job.display_id} on #{node.name}")

--- a/lib/flight_scheduler/time_resolver.rb
+++ b/lib/flight_scheduler/time_resolver.rb
@@ -1,0 +1,63 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+module FlightScheduler
+  class TimeResolver
+    MIN_REGEX               = /\A\d+\Z/
+    MIN_SEC_REGEX           = /\A\d+:\d+\Z/
+    DAY_HOUR_REGEX          = /\A\d+-\d+\Z/
+    HOUR_MIN_SEC_REGEX      = /\A\d+:\d+:\d+\Z/
+    DAY_HOUR_MIN_REGEX      = /\A\d+-\d+:\d+\Z/
+    DAY_HOUR_MIN_SEC_REGEX  = /\A\d+-\d+:\d+:\d+\Z/
+
+    def initialize(string)
+      @string = string
+    end
+
+    def resolve
+      case @string
+      when MIN_REGEX, Integer
+        @string.to_i * 60
+      when MIN_SEC_REGEX
+        m, s = @string.split(':', 2).map(&:to_i)
+        m * 60 + s
+      when DAY_HOUR_REGEX
+        d, h = @string.split('-', 2).map(&:to_i)
+        (d * 24 + h) * 3600
+      when HOUR_MIN_SEC_REGEX
+        h, m, s = @string.split(':', 3).map(&:to_i)
+        (h * 60 + m) * 60 + s
+      when DAY_HOUR_MIN_REGEX
+        d, h, m = @string.split(/[-:]/).map(&:to_i)
+        ((d * 24 + h) * 60 + m) * 60
+      when DAY_HOUR_MIN_SEC_REGEX
+        d, h, m, s = @string.split(/[-:]/).map(&:to_i)
+        ((d * 24 + h) * 60 + m) * 60 + s
+      end
+    end
+  end
+end

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -29,7 +29,7 @@ require 'spec_helper'
 require_relative '../../lib/flight_scheduler/schedulers/fifo_scheduler'
 
 RSpec.describe FifoScheduler, type: :scheduler do
-  let(:partition) { Partition.new(name: 'all', nodes: nodes) }
+  let(:partition) { Partition.new(name: 'all', nodes: nodes, max_time_limit: 10, default_time_limit: 5) }
   let(:nodes) {
     [
       Node.new(name: 'node01'),

--- a/spec/time_resolver_spec.rb
+++ b/spec/time_resolver_spec.rb
@@ -1,0 +1,99 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+require 'spec_helper'
+
+RSpec.describe FlightScheduler::TimeResolver do
+  describe '#resolve' do
+    def calculate(d: 0, h: 0, m: 0, s: 0)
+      ((d * 24 + h) * 60 + m) * 60 + s
+    end
+
+    it 'parses intergers as minutes' do
+      mins = rand(60)
+      expect(described_class.new(mins).resolve).to eq(calculate(m: mins))
+    end
+
+    it 'parses MINUTES syntax' do
+      mins = rand(60)
+      expect(described_class.new(mins.to_s).resolve).to eq(calculate(m: mins))
+    end
+
+    it 'parses MINUTES:SECONDS syntax' do
+      minutes = rand(60)
+      seconds = rand(60)
+      str = "#{minutes}:#{seconds}"
+      expect(described_class.new(str).resolve).to eq(
+        calculate(m: minutes, s: seconds)
+      )
+    end
+
+    it 'parses HOURS:MINUTES:SECONDS syntax' do
+      hours   = rand(24)
+      minutes = rand(60)
+      seconds = rand(60)
+      str = "#{hours}:#{minutes}:#{seconds}"
+      expect(described_class.new(str).resolve).to eq(
+        calculate(h: hours, m: minutes, s: seconds)
+      )
+    end
+
+    it 'parses DAYS-HOURS syntax' do
+      days  = rand(30)
+      hours = rand(24)
+      str = "#{days}-#{hours}"
+      expect(described_class.new(str).resolve).to eq(
+        calculate(d: days, h: hours)
+      )
+    end
+
+    it 'parses DAYS-HOURS:MINUTES syntax' do
+      days    = rand(30)
+      hours   = rand(24)
+      minutes = rand(60)
+      str = "#{days}-#{hours}:#{minutes}"
+      expect(described_class.new(str).resolve).to eq(
+        calculate(d: days, h: hours, m: minutes)
+      )
+    end
+
+    it 'parses DAYS-HOURS:MINUTES:SECONDS syntax' do
+      days    = rand(30)
+      hours   = rand(24)
+      minutes = rand(60)
+      seconds = rand(60)
+      str = "#{days}-#{hours}:#{minutes}:#{seconds}"
+      expect(described_class.new(str).resolve).to eq(
+        calculate(d: days, h: hours, m: minutes, s: seconds)
+      )
+    end
+
+    it 'returns nil for non-matching syntax' do
+      expect(described_class.new('foobar').resolve).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Partition Time Limit

Each partition can optionally define a `max_time_limit` and `default_time_limit`. The default can not be greater than the maximum as this would prevent the any jobs running on the partition by default. However the maximum time limit can act as the de facto default.

It is assumed that any user provided values are given in minutes, which is then converted to seconds internally. Various other synthases are also supported by the new `TimeResolver` class.

---

## Non Blocking Time limit in FifoScheduler

The user can override the default partition time limit with the `time_limit_spec` `Job` attribute. This is internally converted into seconds. A user input of `0` (or anything that resolves to `0`) is considered equivalent to "infinite"/no time limit. This is internally represented as `nil`.

Jobs which exceed the partition maximum time limit (accounting for no time limit jobs) will never be ran. However they do not block the `FiFoScheduler` and instead are flagged with reason `PartitionTimeLimit` before proceeding to the next job.

---

## Changes to Event Processor

The sinlge `job#time_limit` is provided to the daemon with the `JOB_ALLOCATED` message. Enforcing the time limit is controlled exclusively by the daemon.

The `daemon` may respond with a new `JOB_TIMED_OUT` message which flags a time out has occurred. This message only signifies that the time out handler has started. The node should** eventually send `JOB_DEALLOCATED` and may optionally send `NODE_COMPLETED_JOB`/`NODE_FAILED_JOB`. Due to the asynchronous nature of the daemon, these messages could be sent in all most any order.

** The daemon may not respond `NODE_DEALLOCATED` if it has restarted. This is a known bug due to the persistence.

This means on receipt of `JOB_TIMED_OUT` the `job` is transitioned to `TIMINGOUT` or `TIMEOUT` depending if it is in a terminal state. This does mean other terminal states can transition to `TIMEOUT`. Otherwise when a job is deallocated it is transitioned from `TIMINGOUT` to `TIMEOUT`.

---

Other change:
Previously it was assumed that `NODE_COMPLETED_JOB` meant that the job exited normally, whoever their are edge cases when it did. If the job scrip traps `SIGTERM` it may still exit 0 and return success. As such the job may actually be `CANCELLED` or `TIMEOUT`.