### PR TITLE
Allow nodes to dynamically join the scheduler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     async (1.26.2)
       console (~> 1.0)
       nio4r (~> 2.3)
@@ -56,6 +58,8 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.3.1)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jsonapi-serializers (1.0.1)
       activesupport
     localhost (1.1.6)
@@ -85,6 +89,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    public_suffix (4.0.6)
     rack (2.2.3)
     rack-protection (2.1.0)
       rack
@@ -143,6 +148,7 @@ DEPENDENCIES
   factory_bot
   fakefs
   falcon
+  json-schema
   pry
   pry-byebug
   rack-test

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -45,6 +45,7 @@ class Partition
   end
 
   def node_match?(node)
+    return false if @matchers.empty?
     @matchers.all? { |m| m.match?(node) }
   end
 

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -26,8 +26,6 @@
 #==============================================================================
 
 class Partition
-  include ActiveModel::Validations
-
   attr_reader :name, :nodes, :max_time_limit, :default_time_limit
 
   def initialize(
@@ -35,18 +33,16 @@ class Partition
     nodes:,
     default: false,
     default_time_limit: nil,
-    matches: {},
+    matchers: {},
     max_time_limit: nil
   )
     @name = name
     @nodes = nodes
     @default = default
     @default_time_limit = default_time_limit
-    @matches = matches
+    @matchers = matchers
     @max_time_limit = max_time_limit
   end
-
-  validate :validate_matches
 
   def default?
     !!@default
@@ -61,12 +57,5 @@ class Partition
 
   def hash
     ( [self.class, name] + nodes.map(&:hash) ).hash
-  end
-
-  def validate_matches
-    if @matches.is_a? Hash
-    else
-      @errors.add(:matches, 'must be a hash')
-    end
   end
 end

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -44,6 +44,10 @@ class Partition
     @max_time_limit = max_time_limit
   end
 
+  def node_match?(node)
+    @matchers.all? { |m| m.match?(node) }
+  end
+
   def default?
     !!@default
   end

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -259,14 +259,7 @@ class WebsocketApp
   end
 
   def update_node(node_name, message)
-    node = FlightScheduler.app.nodes[node_name]
-
-    # Define missing nodes and add them to the partitions.
-    if node.nil?
-      node = FlightScheduler.app.nodes.fetch_or_add(node_name)
-      FlightScheduler.app.partitions.select { |p| p.node_match?(node) }
-                     .each { |p| p.nodes.push node }
-    end
+    node = FlightScheduler.app.nodes.fetch_or_add(node_name)
 
     attributes = node.attributes.dup
     attributes.cpus   = message[:cpus]    if message.key?(:cpus)
@@ -291,6 +284,10 @@ class WebsocketApp
         #{attributes.errors.messages}
       ERROR
     end
+
+    FlightScheduler.app.partitions
+      .select { |p| p.node_match?(node) }
+      .each { |p| p.nodes.push node }
   end
 
   def call(env)

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -286,6 +286,7 @@ class WebsocketApp
     end
 
     FlightScheduler.app.partitions
+      .reject { |p| p.nodes.include?(node) }
       .select { |p| p.node_match?(node) }
       .each { |p| p.nodes.push node }
   end

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -285,10 +285,16 @@ class WebsocketApp
       ERROR
     end
 
-    FlightScheduler.app.partitions
-      .reject { |p| p.nodes.include?(node) }
-      .select { |p| p.node_match?(node) }
-      .each { |p| p.nodes.push node }
+    FlightScheduler.app.partitions.each do |partition|
+      match = partition.node_match?(node)
+      existing = partition.nodes.include?(node)
+
+      if match && !existing
+        partition.nodes.push node
+      elsif existing && !match
+        partition.nodes.delete node
+      end
+    end
   end
 
   def call(env)

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -83,6 +83,6 @@ partitions:
     default: true
     max_time_limit: 10
     default_time_limit: 1
-    nodes:
-      - node01
-      - node02
+    node_matches:
+      name:
+        regex: ".*"

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -86,5 +86,5 @@ partitions:
     node_matches:
       name:
         regex: ".*"
-  - name: other
-    nodes: [node01, node02]
+  # - name: other
+  #   nodes: [node01, node02]

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -86,3 +86,5 @@ partitions:
     node_matches:
       name:
         regex: ".*"
+  - name: other
+    nodes: [node01, node02]

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -37,6 +37,7 @@ module FlightScheduler
   autoload(:EventProcessor, 'flight_scheduler/event_processor')
   autoload(:JobRegistry, 'flight_scheduler/job_registry')
   autoload(:LoadBalancer, 'flight_scheduler/load_balancer')
+  autoload(:NodeMatcher, 'flight_scheduler/node_matcher')
   autoload(:NodeRegistry, 'flight_scheduler/node_registry')
   autoload(:PathGenerator, 'flight_scheduler/path_generator')
   autoload(:Persistence, 'flight_scheduler/persistence')

--- a/lib/flight_scheduler/configuration.rb
+++ b/lib/flight_scheduler/configuration.rb
@@ -107,9 +107,12 @@ module FlightScheduler
         partition_nodes = spec['nodes'].map { |node_name| nodes.fetch_or_add(node_name) }
         max, default = parse_times(spec['max_time_limit'], spec['default_time_limit'], name: spec['name'])
         Partition.new(
-          default: spec['default'], name: spec['name'], nodes: partition_nodes,
-          max_time_limit: max, default_time_limit: default
-        )
+          default: spec['default'],
+          default_time_limit: default,
+          max_time_limit: max,
+          name: spec['name'],
+          nodes: partition_nodes,
+        ).tap(&:validate!)
       end
     end
 

--- a/lib/flight_scheduler/configuration.rb
+++ b/lib/flight_scheduler/configuration.rb
@@ -116,6 +116,12 @@ module FlightScheduler
           matchers: matchers,
         )
       end
+      @partitions.each do |partition|
+        (nodes.each.to_a - partition.nodes).each do |node|
+          next unless partition.node_match?(node)
+          partition.nodes.push node
+        end
+      end
     end
 
     private

--- a/lib/flight_scheduler/node_matcher.rb
+++ b/lib/flight_scheduler/node_matcher.rb
@@ -59,6 +59,10 @@ module FlightScheduler
       @errors.empty?
     end
 
+    def match?(node)
+      value = node.send(key)
+      specs.keys.all? { |k| self.send(k, value) }
+    end
 
     # NOTE: The following methods are public to facilitate testing
     # The methods are only intended to be called if they have a corresponding spec entry

--- a/lib/flight_scheduler/node_matcher.rb
+++ b/lib/flight_scheduler/node_matcher.rb
@@ -59,8 +59,32 @@ module FlightScheduler
       @errors.empty?
     end
 
+
+    # NOTE: The following methods are public to facilitate testing
+    # The methods are only intended to be called if they have a corresponding spec entry
+    # Calling a method without a spec entry is undefined
     def regex(str)
       Regexp.new(specs['regex']).match?(str.to_s)
+    end
+
+    def lt(int)
+      return false unless int.is_a? Integer
+      int < specs['lt']
+    end
+
+    def lte(int)
+      return false unless int.is_a? Integer
+      int <= specs['lte']
+    end
+
+    def gt(int)
+      return false unless int.is_a? Integer
+      int > specs['gt']
+    end
+
+    def gte(int)
+      return false unless int.is_a? Integer
+      int >= specs['gte']
     end
   end
 end

--- a/lib/flight_scheduler/node_matcher.rb
+++ b/lib/flight_scheduler/node_matcher.rb
@@ -31,7 +31,6 @@ module FlightScheduler
   class NodeMatcher
 
     KEYS = ['name', 'cpus', 'gpus']
-    MATCHERS = ['regex', 'lt', 'gt']
 
     # Used to validate the matcher provided by the user
     SCHEMA = {
@@ -40,7 +39,11 @@ module FlightScheduler
       "additionalProperties": false,
       "properties" => {
         "key" => { "type" => "string", "enum" => KEYS },
-        "regex" => { "type" => "string" }
+        "regex" => { "type" => "string" },
+        'lt' => { "type" => 'integer' },
+        'lte' => { "type" => 'integer' },
+        'gt' => { "type" => 'integer' },
+        'gte' => { "type" => 'integer' }
       }
     }
 

--- a/lib/flight_scheduler/node_matcher.rb
+++ b/lib/flight_scheduler/node_matcher.rb
@@ -54,10 +54,13 @@ module FlightScheduler
       @specs = specs.transform_keys(&:to_s)
     end
 
-
     def valid?
       @errors = JSON::Validator.fully_validate(SCHEMA, { "key" => key }.merge(specs))
       @errors.empty?
+    end
+
+    def regex(str)
+      Regexp.new(specs['regex']).match?(str.to_s)
     end
   end
 end

--- a/lib/flight_scheduler/node_matcher.rb
+++ b/lib/flight_scheduler/node_matcher.rb
@@ -30,7 +30,7 @@ require 'json-schema'
 module FlightScheduler
   class NodeMatcher
 
-    KEYS = ['name', 'cpus', 'gpus']
+    KEYS = ['name', 'cpus', 'gpus', 'memory']
 
     # Used to validate the matcher provided by the user
     SCHEMA = {

--- a/lib/flight_scheduler/node_registry.rb
+++ b/lib/flight_scheduler/node_registry.rb
@@ -31,6 +31,10 @@ class FlightScheduler::NodeRegistry
     @mutex = Mutex.new
   end
 
+  def each
+    block_given? ? @nodes.each { |_, n| yield(n) } : @nodes.values.each
+  end
+
   def fetch_or_add(node_name)
     @mutex.synchronize do
       if @nodes.key? node_name

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,9 +26,17 @@
 #==============================================================================
 
 FactoryBot.define do
+  factory :partition do
+    sequence(:name) { |n| "demo-partition#{n}" }
+    nodes { [] }
+    default { false }
+
+    initialize_with { new(**attributes) }
+  end
+
   factory :job do
     id { SecureRandom.uuid }
-    partition { FlightScheduler.app.default_partition }
+    partition
     min_nodes { 1 }
     state { 'PENDING' }
     reason_pending { 'WaitingForScheduling' }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -89,4 +89,12 @@ FactoryBot.define do
       new(name: name, attributes: attributes)
     end
   end
+
+  factory :node_matcher, class: 'FlightScheduler::NodeMatcher' do
+    key { 'name' }
+    initialize_with do
+      attr = attributes.dup
+      new(attr.delete(:key), **attr)
+    end
+  end
 end

--- a/spec/models/partition_spec.rb
+++ b/spec/models/partition_spec.rb
@@ -25,48 +25,19 @@
 # https://github.com/openflighthpc/flight-scheduler-controller
 #==============================================================================
 
-class Partition
-  include ActiveModel::Validations
+require 'spec_helper'
 
-  attr_reader :name, :nodes, :max_time_limit, :default_time_limit
+RSpec.describe Partition, type: :model do
+  let(:job) {
+    Job.new(
+      id: 1,
+      min_nodes: '2',
+    )
+  }
 
-  def initialize(
-    name:,
-    nodes:,
-    default: false,
-    default_time_limit: nil,
-    matches: {},
-    max_time_limit: nil
-  )
-    @name = name
-    @nodes = nodes
-    @default = default
-    @default_time_limit = default_time_limit
-    @matches = matches
-    @max_time_limit = max_time_limit
-  end
-
-  validate :validate_matches
-
-  def default?
-    !!@default
-  end
-
-  def ==(other)
-    self.class == other.class &&
-      name == other.name &&
-      nodes == other.nodes
-  end
-  alias eql? ==
-
-  def hash
-    ( [self.class, name] + nodes.map(&:hash) ).hash
-  end
-
-  def validate_matches
-    if @matches.is_a? Hash
-    else
-      @errors.add(:matches, 'must be a hash')
+  describe '#matches' do
+    specify 'a string is not valid' do
+      expect(build(:partition, matches: 'foobar')).not_to be_valid
     end
   end
 end

--- a/spec/node_matcher_spec.rb
+++ b/spec/node_matcher_spec.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #==============================================================================
 # Copyright (C) 2020-present Alces Flight Ltd.
 #
@@ -26,29 +25,18 @@
 # https://github.com/openflighthpc/flight-scheduler-controller
 #==============================================================================
 
-source "https://rubygems.org"
+require 'spec_helper'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
-gem 'activemodel', require: 'active_model'
-gem 'activesupport', require: 'active_support'
-gem 'async-websocket'
-gem 'concurrent-ruby', require: 'concurrent'
-gem 'falcon'
-gem 'json-schema'
-gem 'sinatra'
-gem 'sinatra-cors'
-gem 'sinja', '>= 1.3.0'
-gem 'swagger-blocks'
-
-group :test do
-  group :development do
-    gem 'pry'
-    gem 'pry-byebug'
+RSpec.describe FlightScheduler::NodeMatcher do
+  specify 'unrecognised keys are invalid' do
+    expect(described_class.new('foobar')).not_to be_valid
   end
 
-  gem 'rspec'
-  gem 'fakefs', require: 'fakefs/safe'
-  gem 'rack-test'
-  gem 'factory_bot'
+  specify 'recognised strings are valid' do
+    expect(described_class.new('name')).to be_valid
+  end
+
+  specify 'unrecognised matchers are invalid' do
+    expect(described_class.new('name', foobiz: nil)).not_to be_valid
+  end
 end

--- a/spec/node_matcher_spec.rb
+++ b/spec/node_matcher_spec.rb
@@ -47,6 +47,86 @@ RSpec.describe FlightScheduler::NodeMatcher do
     end
   end
 
+  describe '#lt' do
+    let(:value) { 10 }
+
+    it 'returns false for non-integers' do
+      expect(build(:node_matcher, lt: 1).lt('foo')).to be false
+    end
+
+    it 'is true for less than' do
+      expect(build(:node_matcher, lt: value).lt(value - 1)).to be true
+    end
+
+    it 'is false for equal' do
+      expect(build(:node_matcher, lt: value).lt(value)).to be false
+    end
+
+    it 'is false for greater than' do
+      expect(build(:node_matcher, lt: value).lt(value + 1)).to be false
+    end
+  end
+
+  describe '#lte' do
+    let(:value) { 10 }
+
+    it 'returns false for non-integers' do
+      expect(build(:node_matcher, lte: 1).lte('foo')).to be false
+    end
+
+    it 'is true for less than' do
+      expect(build(:node_matcher, lte: value).lte(value - 1)).to be true
+    end
+
+    it 'is true for equal' do
+      expect(build(:node_matcher, lte: value).lte(value)).to be true
+    end
+
+    it 'is false for greater than' do
+      expect(build(:node_matcher, lte: value).lte(value + 1)).to be false
+    end
+  end
+
+  describe '#gt' do
+    let(:value) { 10 }
+
+    it 'returns false for non-integers' do
+      expect(build(:node_matcher, gt: 1).gt('foo')).to be false
+    end
+
+    it 'is false for less than' do
+      expect(build(:node_matcher, gt: value).gt(value - 1)).to be false
+    end
+
+    it 'is false for equal' do
+      expect(build(:node_matcher, gt: value).gt(value)).to be false
+    end
+
+    it 'is true for greater than' do
+      expect(build(:node_matcher, gt: value).gt(value + 1)).to be true
+    end
+  end
+
+  describe '#gte' do
+    let(:value) { 10 }
+
+    it 'returns false for non-integers' do
+      expect(build(:node_matcher, gte: 1).gte('foo')).to be false
+    end
+
+    it 'is false for less than' do
+      expect(build(:node_matcher, gte: value).gte(value - 1)).to be false
+    end
+
+    it 'is true for equal' do
+      expect(build(:node_matcher, gte: value).gte(value)).to be true
+    end
+
+    it 'is true for greater than' do
+      expect(build(:node_matcher, gte: value).gte(value + 1)).to be true
+    end
+  end
+
   describe '#regex' do
     it 'can match' do
       expect(build(:node_matcher, regex: 'node').regex('node')).to be true

--- a/spec/node_matcher_spec.rb
+++ b/spec/node_matcher_spec.rb
@@ -39,4 +39,11 @@ RSpec.describe FlightScheduler::NodeMatcher do
   specify 'unrecognised matchers are invalid' do
     expect(described_class.new('name', foobiz: nil)).not_to be_valid
   end
+
+  ['lt', 'gt', 'gte', 'lte'].each do |type|
+    specify "#{type} must be an integer" do
+      expect(described_class.new('name', type.to_sym => '1')).not_to be_valid
+      expect(described_class.new('name', type.to_sym => 1)).to be_valid
+    end
+  end
 end

--- a/spec/node_matcher_spec.rb
+++ b/spec/node_matcher_spec.rb
@@ -37,13 +37,36 @@ RSpec.describe FlightScheduler::NodeMatcher do
   end
 
   specify 'unrecognised matchers are invalid' do
-    expect(described_class.new('name', foobiz: nil)).not_to be_valid
+    expect(build(:node_matcher, foobiz: nil)).not_to be_valid
   end
 
   ['lt', 'gt', 'gte', 'lte'].each do |type|
     specify "#{type} must be an integer" do
-      expect(described_class.new('name', type.to_sym => '1')).not_to be_valid
-      expect(described_class.new('name', type.to_sym => 1)).to be_valid
+      expect(build(:node_matcher, type.to_sym => '1')).not_to be_valid
+      expect(build(:node_matcher, type.to_sym => 1)).to be_valid
+    end
+  end
+
+  describe '#regex' do
+    it 'can match' do
+      expect(build(:node_matcher, regex: 'node').regex('node')).to be true
+    end
+
+    it 'does not perform a bound match by default' do
+      expect(build(:node_matcher, regex: 'node').regex('foo-node-bar')).to be true
+    end
+
+    it 'can preform a bound match' do
+      expect(build(:node_matcher, regex: '\Anode\Z').regex('node')).to be true
+      expect(build(:node_matcher, regex: '\Anode\Z').regex('foo-node-bar')).to be false
+    end
+
+    it 'handles integers' do
+      expect(build(:node_matcher, regex: '\d+').regex(1)).to be true
+    end
+
+    it 'can wild card match' do
+      expect(build(:node_matcher, regex: '\Anode\d+\Z').regex('node01')).to be true
     end
   end
 end


### PR DESCRIPTION
The scheduler now supports a flexible config syntax. This allows it to match the `name`, `cpus`, and `gpus` fields against a set of built in matchers: `regex`,`lt`, `lte`, `gt`, and `gte`.

The statically defined nodes will be implicitly added to any partition they match. This means all nodes join the `ALL` partition by default. When an unrecognised node joins the scheduler, it will be implicitly created and added to the appropriate partitions. It currently is a _Hotel California_, nodes can disconnect but never leave the scheduler.