### PR TITLE
Backfilling scheduler

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -95,4 +95,14 @@ class Node
   def hash
     [self.class, name].hash
   end
+
+  # A static view of whether this node is suitable for the given job.  This
+  # does considers the current state of node but not its allocations.
+  def satisfies_job?(job)
+    return false if state == 'DOWN'
+    key_map = FlightScheduler::AllocationRegistry::KEY_MAP
+    key_map.all? do |node_key, job_key|
+      (self.send(node_key) || 0) >= job.send(job_key)
+    end
+  end
 end

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -77,6 +77,13 @@
 # Default: 30 seconds
 # timer_timeout: 30
 
+# Scheduler algorithm.  The algorithm to use for allocating nodes to jobs, aka, scheduling.
+# Valid values are 'fifo', 'backfilling'.
+# Environment variable FLIGHT_SCHEDULER_SCHEDULER_ALGORITHM takes precedence
+# over this setting.
+# Default: backfilling
+# scheduler_algorithm: backfilling
+
 # Partitions.
 partitions:
   - name: all

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -149,9 +149,12 @@ class FlightScheduler::AllocationRegistry
     values.each(&block)
   end
 
-  def max_parallel_per_node(job, node)
+  def max_parallel_per_node(job, node, excluding_job: nil)
     # Determine the existing allocations
     allocations = @lock.with_read_lock { @node_allocations[node.name] }
+    if excluding_job
+      allocations -= [for_job(excluding_job.id)].compact
+    end
     allocated = allocated_resources(*allocations)
 
     # Handle jobs with exclusive accesse

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -50,7 +50,12 @@ module FlightScheduler
     end
 
     def scheduler
-      @scheduler ||= @schedulers.load(:fifo)
+      @scheduler ||=
+        begin
+          algorithm = config.scheduler_algorithm
+          Async.logger.info("Using #{algorithm.inspect} scheduling algorithm")
+          @schedulers.load(algorithm.to_sym)
+        end
     end
 
     def partitions

--- a/lib/flight_scheduler/configuration.rb
+++ b/lib/flight_scheduler/configuration.rb
@@ -86,6 +86,11 @@ module FlightScheduler
         env_var: false,
         default: 30,
       },
+      {
+        name: :scheduler_algorithm,
+        env_var: true,
+        default: 'backfilling',
+      },
     ]
     attr_accessor(*ATTRIBUTES.map { |a| a[:name] })
 

--- a/lib/flight_scheduler/schedulers/backfilling_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/backfilling_scheduler.rb
@@ -1,0 +1,222 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+class BackfillingScheduler
+  FlightScheduler.app.schedulers.register(:backfilling, self)
+
+  class InvalidJobType < RuntimeError; end
+
+  # Stores data for the backfilling algorithm.
+  #
+  # * shortage of nodes to run all skipped jobs.
+  # * how many nodes can be allocated to other jobs without delaying any
+  #   skipped jobs.
+  class Backfill < Struct.new(:shortage, :available)
+  end
+
+  attr_reader :queue
+
+  def initialize
+    @allocation_mutex = Mutex.new
+  end
+
+  # Allocate any jobs that can be scheduled.
+  #
+  # In order for a job to be scheduled, the partition must contain sufficient
+  # available resources to meet the job's requirements.
+  def allocate_jobs
+    new_allocations = []
+    @allocation_mutex.synchronize do
+      backfill = Backfill.new(0, nil)
+      candidates = self.candidates
+
+      loop do
+        candidate = candidates.next
+        break if candidate.nil?
+
+        if backfill.available && candidate.min_nodes > backfill.available
+          break
+        end
+
+        allocation = allocate_job(candidate)
+        if allocation.nil?
+          # The job cannot be allocated at the moment.
+          #
+          # 1. Determine how many nodes short we are.
+          # 2. Determine what the minimum number of nodes will be released
+          #    when the next job completes.
+          # 3. If the difference between 1 and 2 is positive, that is how many
+          #    nodes can be backfilled.
+          #
+          required_nodes = candidate.min_nodes
+          available_nodes = candidate.partition.nodes.select { |n| n.allocations.empty? }.length
+          node_shortage += required_nodes - available_nodes
+
+          min_node_release =
+            FlightScheduler.app.job_registry.jobs
+            .select { |j| j.allocated? }
+            .map { |j| j.allocation }
+            .map { |a| a.nodes.select { |n| candidate.partition.nodes.include?(n) } }
+            .map { |n| n.length }
+            .min || 0
+
+          backfill.available = min_node_release - backfill.shortage
+
+          if backfill.available > 0
+            next
+          else
+            break
+          end
+        else
+          if backfill.available
+            backfill.available -= allocation.nodes.length
+          end
+          new_allocations << allocation
+        end
+      rescue StopIteration
+        # We've considered all jobs in the queue.
+        break
+      end
+
+      # We've exited the allocation loop. Any jobs left 'WaitingForScheduling'
+      # are blocked on priority.  We'll update a few of them to show that is
+      # the case.
+      #
+      # A more complicated scheduler would likely do this whilst iterating
+      # over the jobs.
+      candidates
+        .take(5)
+        .select { |job| job.reason_pending == 'WaitingForScheduling' }
+        .each { |job| job.reason_pending = 'Priority' }
+    end
+    new_allocations
+  end
+
+  def queue
+    # For the backfilling scheduler, the queue is sorted and slightly filtered
+    # view of the registry of jobs.
+    #
+    # The sorting and filtering is primarily intended for display purposes,
+    # but also using it for processing ensures that the jobs are processed in
+    # the order in which the queue output suggests.
+    #
+    # The jobs are sorted to ensure that running jobs are placed higher in the
+    # queue output than pending jobs.
+    #
+    # The jobs are filtered to ensure that array jobs without any pending
+    # tasks are not included.
+    #
+    # A more complicated scheduler may implement a priority queue and need to
+    # keep its own record of the queued jobs rather than using job registry.
+    running_jobs_first = lambda { |job| job.reason_pending.nil? ? -1 : 1 }
+
+    # NOTE: We rely on the sort being stable to ensure that earlier added jobs
+    # are considered prior to later added jobs.
+    FlightScheduler.app.job_registry.jobs
+      .reject { |j| j.job_type == 'ARRAY_JOB' && j.task_generator.finished? }
+      .reject { |j| j.terminal_state? }
+      .sort_by.with_index { |x, idx| [running_jobs_first.call(x), idx] }
+  end
+
+  # Attempt to allocate a single job.
+  #
+  # If the partition has sufficient resources available for the job, a
+  # new +Allocation+ is added to the allocations registry and returned.
+  #
+  # If an allocation is created for an `ARRAY_TASK`, it is added to the job
+  # registry and the associated task generator advanced.
+  #
+  # If there are insufficient resources available to allocate to the job,
+  # the job's `reason_pending` is updated and +nil+ is returned.
+  #
+  # NOTE: It is expected that this will not differ between schedulers.
+  def allocate_job(job, reason: 'Resources')
+    raise InvalidJobType, job if job.job_type == 'ARRAY_JOB'
+
+    # Generate an allocation for the job
+    nodes = job.partition.nodes
+    FlightScheduler::LoadBalancer.new(job: job, nodes: nodes).allocate.tap do |allocation|
+      if allocation.nil?
+        if job.job_type == 'ARRAY_TASK'
+          job.array_job.reason_pending = reason
+        else
+          job.reason_pending = reason
+        end
+        nil
+      else
+        if job.job_type == 'ARRAY_TASK'
+          FlightScheduler.app.job_registry.add(job)
+          job.array_job.task_generator.advance_next_task
+        end
+        FlightScheduler.app.allocations.add(allocation)
+      end
+    end
+  end
+
+  def candidates
+    # The maximum number of queued jobs to consider.
+    max_jobs_to_consider = 50
+    considered = 0
+
+    Enumerator.new do |yielder|
+      queue.each do |job|
+        considered += 1
+        if considered > max_jobs_to_consider
+          break
+        end
+        next unless job.pending? && job.allocation.nil?
+        max_time_limit = job.partition.max_time_limit
+        if max_time_limit && job.time_limit.nil? || job.time_limit > max_time_limit
+          job.reason_pending = 'PartitionTimeLimit'
+          next
+        end
+
+        if job.job_type == 'ARRAY_JOB'
+          previous_task = nil
+          loop do
+            next_task = job.task_generator.next_task
+            if next_task == previous_task
+              # We failed to schedule the ARRAY_TASK.  Move onto the next
+              # ARRAY_JOB or JOB.
+              break
+            elsif next_task.nil?
+              # We've exhausted the ARRAY_JOB.  Move onto the next ARRAY_JOB
+              # or JOB.
+              break
+            else
+              previous_task = next_task
+              yielder << next_task
+            end
+          end
+        else
+          yielder << job
+        end
+      end
+    end
+  end
+end
+

--- a/spec/models/partition_spec.rb
+++ b/spec/models/partition_spec.rb
@@ -34,10 +34,4 @@ RSpec.describe Partition, type: :model do
       min_nodes: '2',
     )
   }
-
-  describe '#matches' do
-    specify 'a string is not valid' do
-      expect(build(:partition, matches: 'foobar')).not_to be_valid
-    end
-  end
 end

--- a/spec/schedulers/backfilling_scheduler_spec.rb
+++ b/spec/schedulers/backfilling_scheduler_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe BackfillingScheduler, type: :scheduler do
   before(:each) { allocations.send(:clear); job_registry.send(:clear) }
 
   include_examples 'basic scheduler specs'
+  include_examples '(basic) #queue specs'
+  include_examples '(basic) job completion or cancellation specs'
 
   describe '#allocate_jobs' do
     def make_job(job_id, min_nodes, **kwargs)
@@ -193,281 +195,81 @@ RSpec.describe BackfillingScheduler, type: :scheduler do
         end
       end
 
-      # context 'for array jobs' do
-      #   class TestData < Struct.new(:job_id, :array, :min_nodes, :run_time, :allocations_in_round)
-      #     def initialize(*args)
-      #       super
-      #       @run_time_for_tasks = {}
-      #     end
+      context 'for array jobs' do
+        class TestDataBackFill < Struct.new(:job_id, :array, :min_nodes, :run_time, :allocations_in_round)
+          def initialize(*args)
+            super
+            @run_time_for_tasks = {}
+          end
 
-      #     def reduce_remaining_runtime(allocation)
-      #       @run_time_for_tasks[allocation] ||= run_time
-      #       @run_time_for_tasks[allocation] -= 1
-      #     end
+          def reduce_remaining_runtime(allocation)
+            @run_time_for_tasks[allocation] ||= run_time
+            @run_time_for_tasks[allocation] -= 1
+          end
 
-      #     def completed_tasks
-      #       @run_time_for_tasks.select { |key, value| value == 0 }.keys
-      #     end
-      #   end
+          def completed_tasks
+            @run_time_for_tasks.select { |key, value| value == 0 }.keys
+          end
+        end
 
-      #   let(:test_data) {
-      #     [
-      #       #           Job id, array, min_nodes, run_time, allocations_in_round
-      #       TestData.new(1,     '1-2', 1,         2,        { 1 => 2 }),
-      #       TestData.new(2,     '1-2', 3,         3,        { 3 => 1, 6 => 1 }),
-      #       TestData.new(3,     '1-2', 2,         3,        { 9 => 2 }),
-      #       TestData.new(4,     '1-5', 1,         1,        { 12 => 4, 13 => 1 }),
-      #       TestData.new(5,     '1-2', 3,         1,        { 13 => 1, 14 => 1 }),
-      #       TestData.new(6,     '1-2', 2,         1,        { 15 => 2 }),
-      #     ]
-      #   }
+        let(:test_data) {
+          [
+            #                   Job id, array, min_nodes, run_time, allocations_in_round
+            TestDataBackFill.new(1,     '1-2', 2,         2,        { 1 => 2 }),
+            TestDataBackFill.new(2,     '1-2', 3,         3,        { 3 => 1, 4 => 1 }),
+            TestDataBackFill.new(3,     '1-2', 1,         3,        { 1 => 1, 6 => 1 }),
+            TestDataBackFill.new(4,     '1-2', 3,         1,        { 7 => 1, 8 => 1}),
+            TestDataBackFill.new(5,     '1-5', 1,         1,        { 8 => 2, 9 => 3 }),
+            TestDataBackFill.new(6,     '1-2', 2,         2,        { 9 => 1, 10 => 1 }),
+            TestDataBackFill.new(7,     '1-2', 1,         1,        { 10 => 2 }),
+          ]
+        }
 
-      #   before(:each) {
-      #     test_data.each do |datum|
-      #       job = make_job(datum.job_id, datum.min_nodes, array: datum.array)
-      #       job_registry.add(job)
-      #     end
-      #   }
+        before(:each) {
+          test_data.each do |datum|
+            job = make_job(datum.job_id, datum.min_nodes, array: datum.array)
+            job_registry.add(job)
+          end
+        }
 
-      #   it 'allocates the correct nodes to the correct jobs in the correct order' do
-      #     num_rounds = test_data.map { |d| d.allocations_in_round.keys }.flatten.max
-      #     num_rounds.times.each do |round|
-      #       round += 1
+        it 'allocates the correct nodes to the correct jobs in the correct order' do
+          num_rounds = test_data.map { |d| d.allocations_in_round.keys }.flatten.max
+          num_rounds.times.each do |round|
+            round += 1
 
-      #       # Progress any completed jobs.
-      #       allocations.each do |allocation|
-      #         datum = test_data.detect { |d| d.job_id == allocation.job.array_job.id }
-      #         datum.reduce_remaining_runtime(allocation)
-      #         datum.completed_tasks.each do |allocation|
-      #           allocation.nodes.dup.each do |node|
-      #             allocations.deallocate_node_from_job(allocation.job.id, node.name)
-      #           end
-      #           allocation.job.state = 'COMPLETED'
-      #         end
-      #       end
+            # Progress any completed jobs.
+            allocations.each do |allocation|
+              datum = test_data.detect { |d| d.job_id == allocation.job.array_job.id }
+              datum.reduce_remaining_runtime(allocation)
+              datum.completed_tasks.each do |allocation|
+                allocation.nodes.dup.each do |node|
+                  allocations.deallocate_node_from_job(allocation.job.id, node.name)
+                end
+                allocation.job.state = 'COMPLETED'
+              end
+            end
 
-      #       array_jobs_with_allocations_this_round = test_data
-      #         .select { |d| d.allocations_in_round[round] }
-      #       total_allocations_this_round = array_jobs_with_allocations_this_round
-      #         .map { |d| d.allocations_in_round[round] }
-      #         .sum
+            array_jobs_with_allocations_this_round = test_data
+              .select { |d| d.allocations_in_round[round] }
+            total_allocations_this_round = array_jobs_with_allocations_this_round
+              .map { |d| d.allocations_in_round[round] }
+              .sum
 
-      #       new_allocations = scheduler.allocate_jobs
-      #       expect(new_allocations.length).to eq total_allocations_this_round
+            new_allocations = scheduler.allocate_jobs
+            expect(new_allocations.length).to eq total_allocations_this_round
 
-      #       allocations_by_array_job = new_allocations.group_by do |allocation|
-      #         allocation.job.array_job.id
-      #       end
+            allocations_by_array_job = new_allocations.group_by do |allocation|
+              allocation.job.array_job.id
+            end
 
-      #       array_jobs_with_allocations_this_round.each do |datum|
-      #         allocations = allocations_by_array_job[datum.job_id]
-      #         expect(allocations.length).to eq datum.allocations_in_round[round]
-      #       end
-      #     end
-      #   end
-      # end
+            array_jobs_with_allocations_this_round.each do |datum|
+              allocations = allocations_by_array_job[datum.job_id]
+              expect(allocations.length).to eq datum.allocations_in_round[round]
+            end
+          end
+        end
+      end
     end
   end
 
-  # describe '#queue' do
-  #   context 'with a fresh sceduler' do
-  #     it 'is empty' do
-  #       expect(subject.queue).to be_empty
-  #     end
-  #   end
-
-  #   context 'with multiple batch jobs' do
-  #     let(:jobs) do
-  #       (rand(10) + 1).times.map { build(:job, min_nodes: 1, partition: partition) }
-  #     end
-
-  #     before { jobs.each { |j| job_registry.add(j) } }
-
-  #     it 'matches the jobs' do
-  #       expect(subject.queue).to eq(jobs)
-  #     end
-
-  #     context 'after allocation' do
-  #       before { subject.allocate_jobs }
-
-  #       it 'matches the jobs' do
-  #         expect(subject.queue).to eq(jobs)
-  #       end
-  #     end
-  #   end
-
-  #   context 'with a single array job with parity between nodes and tasks' do
-  #     let(:job) do
-  #       build(:job, array: "1-#{nodes.length}", partition: partition, min_nodes: 1)
-  #     end
-
-  #     before { job_registry.add(job) }
-
-  #     it 'contains the single job' do
-  #       expect(subject.queue).to contain_exactly(job)
-  #     end
-
-  #     context 'after allocation' do
-  #       before { subject.allocate_jobs }
-
-  #       it 'does not contain the main job' do
-  #         expect(subject.queue).not_to include(job)
-  #       end
-
-  #       it 'does contain the tasks' do
-  #         expect(subject.queue.length).to eq(nodes.length)
-  #         expect(subject.queue.map(&:array_index)).to contain_exactly(*(1..nodes.length))
-  #         subject.queue.each do |task|
-  #           expect(task).to be_a(Job)
-  #           expect(task.job_type).to eq('ARRAY_TASK')
-  #           expect(task.array_job).to eq(job)
-  #         end
-  #       end
-  #     end
-  #   end
-
-  #   context 'with a single array job with excess tasks' do
-  #     let(:max_index) { nodes.length + 1 + rand(10) }
-  #     let(:job) do
-  #       build(:job, array: "1-#{max_index}", partition: partition, min_nodes: 1)
-  #     end
-
-  #     before { job_registry.add(job) }
-
-  #     it 'contains the single job' do
-  #       expect(subject.queue).to contain_exactly(job)
-  #     end
-
-  #     context 'after allocation' do
-  #       before { subject.allocate_jobs }
-
-  #       it 'contains the main job in the last position' do
-  #         expect(subject.queue.last).to eq(job)
-  #       end
-
-  #       it 'contains tasks in the subsequent positions' do
-  #         remaining = subject.queue.dup.tap(&:pop)
-  #         expect(remaining.length).to eq(nodes.length)
-  #         expect(remaining.map(&:array_index)).to contain_exactly(*(1..nodes.length))
-  #         remaining.each do |task|
-  #           expect(task).to be_a(Job)
-  #           expect(task.job_type).to eq('ARRAY_TASK')
-  #           expect(task.array_job).to eq(job)
-  #         end
-  #       end
-  #     end
-  #   end
-  # end
-
-  # describe 'job removal (completion or cancellation)' do
-  #   context 'with multiple batch jobs' do
-  #     let(:jobs) do
-  #       (rand(10) + 1).times.map { build(:job, min_nodes: 1, partition: partition) }
-  #     end
-  #     let(:job) { jobs.sample }
-  #     before { jobs.each { |j| job_registry.add(j) } }
-
-  #     context 'after completing an allocated job' do
-  #       before do
-  #         subject.allocate_jobs
-  #         job.state = 'COMPLETED'
-  #       end
-
-  #       it 'does not appear in the queue' do
-  #         expect(subject.queue).not_to include(job)
-  #       end
-  #     end
-  #   end
-
-  #   context 'with a single allocated array job with an execess of tasks' do
-  #     let(:max_index) { nodes.length + 1 + rand(10) }
-  #     let(:job) do
-  #       build(:job, array: "1-#{max_index}", partition: partition, min_nodes: 1)
-  #     end
-
-  #     before do
-  #       job_registry.add(job)
-  #       subject.allocate_jobs
-  #     end
-
-  #     context 'after completing and removing the allocated ARRAY_JOB' do
-  #       before do
-  #         job_registry.tasks_for(job).each do |task|
-  #           task.state = 'COMPLETED'
-  #           allocation = FlightScheduler.app.allocations.for_job(task)
-  #           if allocation
-  #             allocation.nodes.each do |node|
-  #               FlightScheduler.app.allocations.deallocate_node_from_job(task.id, node.name)
-  #             end
-  #           end
-  #         end
-  #         job.state = 'COMPLETED'
-  #         job_registry.remove_old_jobs
-  #       end
-
-  #       it 'does not appear in the queue' do
-  #         expect(subject.queue).to be_empty
-  #       end
-  #     end
-
-  #     context 'after removing an ARRAY_TASK' do
-  #       let(:task) do
-  #         subject.queue[0..-2].sample
-  #       end
-  #       let(:other_tasks) { subject.queue[0..-2] - [task] }
-
-  #       before do
-  #         expect(task.job_type).to eq('ARRAY_TASK')
-  #         other_tasks # Ensure other_tasks is initialized
-  #         task.state = 'COMPLETED'
-  #       end
-
-  #       it 'includes the main job and other tasks in the queue' do
-  #         expect(subject.queue).to contain_exactly(job, *other_tasks)
-  #       end
-
-  #       it 'does not include the task in the queue' do
-  #         expect(subject.queue).not_to include(task)
-  #       end
-  #     end
-
-  #     context 'after completing all ARRAY_TASKs' do
-  #       before do
-  #         subject.queue.dup.each do |job|
-  #           next unless job.job_type == 'ARRAY_TASK'
-  #           job.state = 'COMPLETED'
-  #         end
-  #       end
-
-  #       it 'only includes the main job in the queue' do
-  #         expect(subject.queue).to contain_exactly(job)
-  #       end
-  #     end
-  #   end
-
-  #   context 'with a single allocated array job with parity between tasks and nodes' do
-  #     let(:job) do
-  #       build(:job, array: "1-#{nodes.length}", partition: partition, min_nodes: 1)
-  #     end
-
-  #     before do
-  #       job_registry.add(job)
-  #       subject.allocate_jobs
-  #     end
-
-  #     context 'after completing all the tasks' do
-  #       before do
-  #         subject.queue.dup.each do |job|
-  #           next unless job.job_type == 'ARRAY_TASK'
-  #           job.state = 'COMPLETED'
-  #         end
-  #       end
-
-  #       it 'removes the main job' do
-  #         expect(subject.queue).to be_empty
-  #       end
-  #     end
-  #   end
-  # end
 end
-

--- a/spec/schedulers/backfilling_scheduler_spec.rb
+++ b/spec/schedulers/backfilling_scheduler_spec.rb
@@ -1,0 +1,473 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+require 'spec_helper'
+require_relative '../../lib/flight_scheduler/schedulers/backfilling_scheduler'
+require_relative 'shared_scheduler_spec'
+
+RSpec.describe BackfillingScheduler, type: :scheduler do
+  let(:partition) {
+    Partition.new(name: 'all', nodes: nodes, max_time_limit: 10, default_time_limit: 5)
+  }
+  let(:nodes) {
+    [
+      Node.new(name: 'node01'),
+      Node.new(name: 'node02'),
+      Node.new(name: 'node03'),
+      Node.new(name: 'node04'),
+      Node.new(name: 'node05'),
+      Node.new(name: 'node06'),
+    ].tap do |a|
+      a.each do |node|
+        allow(node).to receive(:connected?).and_return true
+      end
+    end
+  }
+
+  let(:scheduler) { subject }
+  let(:allocations) { FlightScheduler.app.allocations }
+  let(:job_registry) { FlightScheduler.app.job_registry }
+  subject { described_class.new }
+
+  # TODO: The allocations and scheduler shouldn't have to be cleared like this
+  #       Currently the scheduler contains global lookups and thus their can
+  #       only be a single instance. Instead the scheduler should take the
+  #       allocation registry as an input.
+  #
+  #       This will allow a new scheduler to be created for each spec,
+  #       consider refactoring
+  before(:each) { allocations.send(:clear); job_registry.send(:clear) }
+
+  include_examples 'basic scheduler specs'
+
+  describe '#allocate_jobs' do
+    def make_job(job_id, min_nodes, **kwargs)
+      build(:job, id: job_id, min_nodes: min_nodes, partition: partition, **kwargs)
+    end
+
+    def add_allocation(job, nodes)
+      Allocation.new(job: job, nodes: nodes).tap do |allocation|
+        allocations.add(allocation)
+      end
+    end
+
+    context 'when there is an unallocated job that cannot be allocated' do
+      let(:jobs) do
+        min_node_requirements = [
+          # Add two jobs both requiring two nodes.
+          2,
+          2,
+
+          # Add a job requiring three nodes.  The partition currently has only 2
+          # nodes available.
+          3,
+
+          # Add two jobs both requiring a single node.  The partition has
+          # sufficient nodes available for both of these jobs.  However, there
+          # is a higher priority job above them.
+          #
+          # The scheduler will allocate one of these, but not both, as doing
+          # so will not prevent the pending job from running as soon as one of
+          # the running jobs has completed.  Allocating both could prevent
+          # that.
+          1,
+          1,
+        ]
+
+        min_node_requirements.each_with_index.map do |min_nodes, job_id|
+          make_job(job_id, min_nodes)
+        end
+      end
+
+      # Only the first two jobs should be allocated.  The third job cannot be
+      # allocated as their are not sufficient nodes left and the remaining
+      # jobs are blocked by the third.
+      let(:expected_allocated_jobs) { [ jobs[0], jobs[1], jobs[3] ] }
+      let(:expected_unallocated_jobs) { jobs - expected_allocated_jobs }
+
+      before do
+        jobs.each { |j| job_registry.add(j) }
+      end
+
+      it 'creates expected allocations' do
+        expect{ scheduler.allocate_jobs }.to \
+          change { allocations.size }.by(expected_allocated_jobs.length)
+        expected_allocated_jobs.each do |job|
+          expect(allocations.for_job(job.id)).to be_truthy
+        end
+      end
+
+      it 'does not create unexpected allocations' do
+        scheduler.allocate_jobs
+
+        expected_unallocated_jobs.each do |job|
+          expect(allocations.for_job(job.id)).to be_nil
+        end
+      end
+
+      it 'sets the first unallocated job reason to Resources' do
+        first_unallocated = expected_unallocated_jobs.first
+        scheduler.allocate_jobs
+        expect(first_unallocated.reason_pending).to eq('Resources')
+      end
+
+      it 'sets the secondary unallocated job reason to Priority' do
+        secondary_unallocated = expected_unallocated_jobs[1]
+        scheduler.allocate_jobs
+        expect(secondary_unallocated.reason_pending).to eq('Priority')
+      end
+    end
+
+    context 'multiple calls' do
+      context 'for non-array jobs' do
+        let(:test_data) {
+          [
+            { job_id: 1, min_nodes: 2, run_time: 2, allocated_in_round: 1 },
+            { job_id: 2, min_nodes: 2, run_time: 1, allocated_in_round: 1 },
+            { job_id: 3, min_nodes: 3, run_time: 3, allocated_in_round: 2 },
+            { job_id: 4, min_nodes: 1, run_time: 3, allocated_in_round: 1 },
+            { job_id: 5, min_nodes: 1, run_time: 2, allocated_in_round: 3 },
+            { job_id: 6, min_nodes: 2, run_time: 1, allocated_in_round: 4 },
+            { job_id: 7, min_nodes: 1, run_time: 2, allocated_in_round: 5 },
+          ]
+        }
+
+        before(:each) {
+          test_data.each do |datum|
+            job = make_job(datum[:job_id], datum[:min_nodes])
+            job_registry.add(job)
+          end
+        }
+
+        it 'allocates the correct nodes to the correct jobs in the correct order' do
+          num_rounds = test_data.map { |d| d[:allocated_in_round] }.max
+          num_rounds.times.each do |round|
+            round += 1
+
+            # Progress any completed jobs.
+            allocations.each do |allocation|
+              datum = test_data.detect { |d| d[:job_id] == allocation.job.id }
+              datum[:run_time] -= 1
+              if datum[:run_time] == 0
+                allocation.nodes.dup.each do |node|
+                  allocations.deallocate_node_from_job(allocation.job.id, node.name)
+                end
+                allocation.job.state = 'COMPLETED'
+              end
+            end
+
+            expected_allocations = test_data
+              .select { |d| d[:allocated_in_round] == round }
+
+            expect { scheduler.allocate_jobs }.to \
+              change { allocations.size }.by(expected_allocations.length)
+            expected_allocations.each do |datum|
+              allocation = allocations.for_job(datum[:job_id])
+              expect(allocation).not_to be_nil
+            end
+          end
+        end
+      end
+
+      # context 'for array jobs' do
+      #   class TestData < Struct.new(:job_id, :array, :min_nodes, :run_time, :allocations_in_round)
+      #     def initialize(*args)
+      #       super
+      #       @run_time_for_tasks = {}
+      #     end
+
+      #     def reduce_remaining_runtime(allocation)
+      #       @run_time_for_tasks[allocation] ||= run_time
+      #       @run_time_for_tasks[allocation] -= 1
+      #     end
+
+      #     def completed_tasks
+      #       @run_time_for_tasks.select { |key, value| value == 0 }.keys
+      #     end
+      #   end
+
+      #   let(:test_data) {
+      #     [
+      #       #           Job id, array, min_nodes, run_time, allocations_in_round
+      #       TestData.new(1,     '1-2', 1,         2,        { 1 => 2 }),
+      #       TestData.new(2,     '1-2', 3,         3,        { 3 => 1, 6 => 1 }),
+      #       TestData.new(3,     '1-2', 2,         3,        { 9 => 2 }),
+      #       TestData.new(4,     '1-5', 1,         1,        { 12 => 4, 13 => 1 }),
+      #       TestData.new(5,     '1-2', 3,         1,        { 13 => 1, 14 => 1 }),
+      #       TestData.new(6,     '1-2', 2,         1,        { 15 => 2 }),
+      #     ]
+      #   }
+
+      #   before(:each) {
+      #     test_data.each do |datum|
+      #       job = make_job(datum.job_id, datum.min_nodes, array: datum.array)
+      #       job_registry.add(job)
+      #     end
+      #   }
+
+      #   it 'allocates the correct nodes to the correct jobs in the correct order' do
+      #     num_rounds = test_data.map { |d| d.allocations_in_round.keys }.flatten.max
+      #     num_rounds.times.each do |round|
+      #       round += 1
+
+      #       # Progress any completed jobs.
+      #       allocations.each do |allocation|
+      #         datum = test_data.detect { |d| d.job_id == allocation.job.array_job.id }
+      #         datum.reduce_remaining_runtime(allocation)
+      #         datum.completed_tasks.each do |allocation|
+      #           allocation.nodes.dup.each do |node|
+      #             allocations.deallocate_node_from_job(allocation.job.id, node.name)
+      #           end
+      #           allocation.job.state = 'COMPLETED'
+      #         end
+      #       end
+
+      #       array_jobs_with_allocations_this_round = test_data
+      #         .select { |d| d.allocations_in_round[round] }
+      #       total_allocations_this_round = array_jobs_with_allocations_this_round
+      #         .map { |d| d.allocations_in_round[round] }
+      #         .sum
+
+      #       new_allocations = scheduler.allocate_jobs
+      #       expect(new_allocations.length).to eq total_allocations_this_round
+
+      #       allocations_by_array_job = new_allocations.group_by do |allocation|
+      #         allocation.job.array_job.id
+      #       end
+
+      #       array_jobs_with_allocations_this_round.each do |datum|
+      #         allocations = allocations_by_array_job[datum.job_id]
+      #         expect(allocations.length).to eq datum.allocations_in_round[round]
+      #       end
+      #     end
+      #   end
+      # end
+    end
+  end
+
+  # describe '#queue' do
+  #   context 'with a fresh sceduler' do
+  #     it 'is empty' do
+  #       expect(subject.queue).to be_empty
+  #     end
+  #   end
+
+  #   context 'with multiple batch jobs' do
+  #     let(:jobs) do
+  #       (rand(10) + 1).times.map { build(:job, min_nodes: 1, partition: partition) }
+  #     end
+
+  #     before { jobs.each { |j| job_registry.add(j) } }
+
+  #     it 'matches the jobs' do
+  #       expect(subject.queue).to eq(jobs)
+  #     end
+
+  #     context 'after allocation' do
+  #       before { subject.allocate_jobs }
+
+  #       it 'matches the jobs' do
+  #         expect(subject.queue).to eq(jobs)
+  #       end
+  #     end
+  #   end
+
+  #   context 'with a single array job with parity between nodes and tasks' do
+  #     let(:job) do
+  #       build(:job, array: "1-#{nodes.length}", partition: partition, min_nodes: 1)
+  #     end
+
+  #     before { job_registry.add(job) }
+
+  #     it 'contains the single job' do
+  #       expect(subject.queue).to contain_exactly(job)
+  #     end
+
+  #     context 'after allocation' do
+  #       before { subject.allocate_jobs }
+
+  #       it 'does not contain the main job' do
+  #         expect(subject.queue).not_to include(job)
+  #       end
+
+  #       it 'does contain the tasks' do
+  #         expect(subject.queue.length).to eq(nodes.length)
+  #         expect(subject.queue.map(&:array_index)).to contain_exactly(*(1..nodes.length))
+  #         subject.queue.each do |task|
+  #           expect(task).to be_a(Job)
+  #           expect(task.job_type).to eq('ARRAY_TASK')
+  #           expect(task.array_job).to eq(job)
+  #         end
+  #       end
+  #     end
+  #   end
+
+  #   context 'with a single array job with excess tasks' do
+  #     let(:max_index) { nodes.length + 1 + rand(10) }
+  #     let(:job) do
+  #       build(:job, array: "1-#{max_index}", partition: partition, min_nodes: 1)
+  #     end
+
+  #     before { job_registry.add(job) }
+
+  #     it 'contains the single job' do
+  #       expect(subject.queue).to contain_exactly(job)
+  #     end
+
+  #     context 'after allocation' do
+  #       before { subject.allocate_jobs }
+
+  #       it 'contains the main job in the last position' do
+  #         expect(subject.queue.last).to eq(job)
+  #       end
+
+  #       it 'contains tasks in the subsequent positions' do
+  #         remaining = subject.queue.dup.tap(&:pop)
+  #         expect(remaining.length).to eq(nodes.length)
+  #         expect(remaining.map(&:array_index)).to contain_exactly(*(1..nodes.length))
+  #         remaining.each do |task|
+  #           expect(task).to be_a(Job)
+  #           expect(task.job_type).to eq('ARRAY_TASK')
+  #           expect(task.array_job).to eq(job)
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe 'job removal (completion or cancellation)' do
+  #   context 'with multiple batch jobs' do
+  #     let(:jobs) do
+  #       (rand(10) + 1).times.map { build(:job, min_nodes: 1, partition: partition) }
+  #     end
+  #     let(:job) { jobs.sample }
+  #     before { jobs.each { |j| job_registry.add(j) } }
+
+  #     context 'after completing an allocated job' do
+  #       before do
+  #         subject.allocate_jobs
+  #         job.state = 'COMPLETED'
+  #       end
+
+  #       it 'does not appear in the queue' do
+  #         expect(subject.queue).not_to include(job)
+  #       end
+  #     end
+  #   end
+
+  #   context 'with a single allocated array job with an execess of tasks' do
+  #     let(:max_index) { nodes.length + 1 + rand(10) }
+  #     let(:job) do
+  #       build(:job, array: "1-#{max_index}", partition: partition, min_nodes: 1)
+  #     end
+
+  #     before do
+  #       job_registry.add(job)
+  #       subject.allocate_jobs
+  #     end
+
+  #     context 'after completing and removing the allocated ARRAY_JOB' do
+  #       before do
+  #         job_registry.tasks_for(job).each do |task|
+  #           task.state = 'COMPLETED'
+  #           allocation = FlightScheduler.app.allocations.for_job(task)
+  #           if allocation
+  #             allocation.nodes.each do |node|
+  #               FlightScheduler.app.allocations.deallocate_node_from_job(task.id, node.name)
+  #             end
+  #           end
+  #         end
+  #         job.state = 'COMPLETED'
+  #         job_registry.remove_old_jobs
+  #       end
+
+  #       it 'does not appear in the queue' do
+  #         expect(subject.queue).to be_empty
+  #       end
+  #     end
+
+  #     context 'after removing an ARRAY_TASK' do
+  #       let(:task) do
+  #         subject.queue[0..-2].sample
+  #       end
+  #       let(:other_tasks) { subject.queue[0..-2] - [task] }
+
+  #       before do
+  #         expect(task.job_type).to eq('ARRAY_TASK')
+  #         other_tasks # Ensure other_tasks is initialized
+  #         task.state = 'COMPLETED'
+  #       end
+
+  #       it 'includes the main job and other tasks in the queue' do
+  #         expect(subject.queue).to contain_exactly(job, *other_tasks)
+  #       end
+
+  #       it 'does not include the task in the queue' do
+  #         expect(subject.queue).not_to include(task)
+  #       end
+  #     end
+
+  #     context 'after completing all ARRAY_TASKs' do
+  #       before do
+  #         subject.queue.dup.each do |job|
+  #           next unless job.job_type == 'ARRAY_TASK'
+  #           job.state = 'COMPLETED'
+  #         end
+  #       end
+
+  #       it 'only includes the main job in the queue' do
+  #         expect(subject.queue).to contain_exactly(job)
+  #       end
+  #     end
+  #   end
+
+  #   context 'with a single allocated array job with parity between tasks and nodes' do
+  #     let(:job) do
+  #       build(:job, array: "1-#{nodes.length}", partition: partition, min_nodes: 1)
+  #     end
+
+  #     before do
+  #       job_registry.add(job)
+  #       subject.allocate_jobs
+  #     end
+
+  #     context 'after completing all the tasks' do
+  #       before do
+  #         subject.queue.dup.each do |job|
+  #           next unless job.job_type == 'ARRAY_TASK'
+  #           job.state = 'COMPLETED'
+  #         end
+  #       end
+
+  #       it 'removes the main job' do
+  #         expect(subject.queue).to be_empty
+  #       end
+  #     end
+  #   end
+  # end
+end
+

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -27,6 +27,7 @@
 
 require 'spec_helper'
 require_relative '../../lib/flight_scheduler/schedulers/fifo_scheduler'
+require_relative 'shared_scheduler_spec'
 
 RSpec.describe FifoScheduler, type: :scheduler do
   let(:partition) { Partition.new(name: 'all', nodes: nodes, max_time_limit: 10, default_time_limit: 5) }
@@ -57,6 +58,8 @@ RSpec.describe FifoScheduler, type: :scheduler do
   #       consider refactoring
   before(:each) { allocations.send(:clear); job_registry.send(:clear) }
 
+  include_examples 'basic scheduler specs'
+
   describe '#allocate_jobs' do
     def make_job(job_id, min_nodes, **kwargs)
       build(:job, id: job_id, min_nodes: min_nodes, partition: partition, **kwargs)
@@ -65,41 +68,6 @@ RSpec.describe FifoScheduler, type: :scheduler do
     def add_allocation(job, nodes)
       Allocation.new(job: job, nodes: nodes).tap do |allocation|
         allocations.add(allocation)
-      end
-    end
-
-    context 'with the initial empty scheduler' do
-      it 'does not create any allocations' do
-        expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
-      end
-    end
-
-    context 'when all jobs are already allocated' do
-      before(:each) {
-        2.times.each do |job_id|
-          job = make_job(job_id, 1)
-          job_registry.add(job)
-          add_allocation(job, [nodes[job_id]])
-        end
-      }
-
-      it 'does not create any allocations' do
-        expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
-      end
-    end
-
-    context 'when all unallocated jobs can be allocated' do
-      let(:number_jobs) { 2 }
-
-      before(:each) {
-        number_jobs.times.each do |job_id|
-          job = make_job(job_id, 1)
-          job_registry.add(job)
-        end
-      }
-
-      it 'creates an allocation for each job' do
-        expect{ scheduler.allocate_jobs }.to change { allocations.size }.by(number_jobs)
       end
     end
 

--- a/spec/schedulers/shared_scheduler_spec.rb
+++ b/spec/schedulers/shared_scheduler_spec.rb
@@ -1,0 +1,76 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+RSpec.shared_examples 'basic scheduler specs' do
+  describe 'basic #allocate_jobs' do
+    def make_job(job_id, min_nodes, **kwargs)
+      build(:job, id: job_id, min_nodes: min_nodes, partition: partition, **kwargs)
+    end
+
+    def add_allocation(job, nodes)
+      Allocation.new(job: job, nodes: nodes).tap do |allocation|
+        allocations.add(allocation)
+      end
+    end
+
+    context 'with the initial empty scheduler' do
+      it 'does not create any allocations' do
+        expect(scheduler.queue).to be_empty
+        expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
+      end
+    end
+
+    context 'when all jobs are already allocated' do
+      before(:each) {
+        2.times.each do |job_id|
+          job = make_job(job_id, 1)
+          job_registry.add(job)
+          add_allocation(job, [nodes[job_id]])
+        end
+      }
+
+      it 'does not create any allocations' do
+        expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
+      end
+    end
+
+    context 'when all unallocated jobs can be allocated' do
+      let(:number_jobs) { 2 }
+
+      before(:each) {
+        number_jobs.times.each do |job_id|
+          job = make_job(job_id, 1)
+          job_registry.add(job)
+        end
+      }
+
+      it 'creates an allocation for each job' do
+        expect{ scheduler.allocate_jobs }.to change { allocations.size }.by(number_jobs)
+      end
+    end
+  end
+end

--- a/spec/schedulers/shared_scheduler_spec.rb
+++ b/spec/schedulers/shared_scheduler_spec.rb
@@ -26,7 +26,7 @@
 #==============================================================================
 
 RSpec.shared_examples 'basic scheduler specs' do
-  describe 'basic #allocate_jobs' do
+  describe '#allocate_jobs (common)' do
     def make_job(job_id, min_nodes, **kwargs)
       build(:job, id: job_id, min_nodes: min_nodes, partition: partition, **kwargs)
     end
@@ -70,6 +70,211 @@ RSpec.shared_examples 'basic scheduler specs' do
 
       it 'creates an allocation for each job' do
         expect{ scheduler.allocate_jobs }.to change { allocations.size }.by(number_jobs)
+      end
+    end
+  end
+end
+
+RSpec.shared_examples '(basic) #queue specs' do
+  describe '#queue (common)' do
+    context 'with a fresh sceduler' do
+      it 'is empty' do
+        expect(subject.queue).to be_empty
+      end
+    end
+
+    context 'with multiple batch jobs' do
+      let(:jobs) do
+        (rand(10) + 1).times.map { build(:job, min_nodes: 1, partition: partition) }
+      end
+
+      before { jobs.each { |j| job_registry.add(j) } }
+
+      it 'matches the jobs' do
+        expect(subject.queue).to eq(jobs)
+      end
+
+      context 'after allocation' do
+        before { subject.allocate_jobs }
+
+        it 'matches the jobs' do
+          expect(subject.queue).to eq(jobs)
+        end
+      end
+    end
+
+    context 'with a single array job with parity between nodes and tasks' do
+      let(:job) do
+        build(:job, array: "1-#{nodes.length}", partition: partition, min_nodes: 1)
+      end
+
+      before { job_registry.add(job) }
+
+      it 'contains the single job' do
+        expect(subject.queue).to contain_exactly(job)
+      end
+
+      context 'after allocation' do
+        before { subject.allocate_jobs }
+
+        it 'does not contain the main job' do
+          expect(subject.queue).not_to include(job)
+        end
+
+        it 'does contain the tasks' do
+          expect(subject.queue.length).to eq(nodes.length)
+          expect(subject.queue.map(&:array_index)).to contain_exactly(*(1..nodes.length))
+          subject.queue.each do |task|
+            expect(task).to be_a(Job)
+            expect(task.job_type).to eq('ARRAY_TASK')
+            expect(task.array_job).to eq(job)
+          end
+        end
+      end
+    end
+
+    context 'with a single array job with excess tasks' do
+      let(:max_index) { nodes.length + 1 + rand(10) }
+      let(:job) do
+        build(:job, array: "1-#{max_index}", partition: partition, min_nodes: 1)
+      end
+
+      before { job_registry.add(job) }
+
+      it 'contains the single job' do
+        expect(subject.queue).to contain_exactly(job)
+      end
+
+      context 'after allocation' do
+        before { subject.allocate_jobs }
+
+        it 'contains the main job in the last position' do
+          expect(subject.queue.last).to eq(job)
+        end
+
+        it 'contains tasks in the subsequent positions' do
+          remaining = subject.queue.dup.tap(&:pop)
+          expect(remaining.length).to eq(nodes.length)
+          expect(remaining.map(&:array_index)).to contain_exactly(*(1..nodes.length))
+          remaining.each do |task|
+            expect(task).to be_a(Job)
+            expect(task.job_type).to eq('ARRAY_TASK')
+            expect(task.array_job).to eq(job)
+          end
+        end
+      end
+    end
+  end
+end
+
+RSpec.shared_examples '(basic) job completion or cancellation specs' do
+  describe 'job removal (completion or cancellation) (common)' do
+    context 'with multiple batch jobs' do
+      let(:jobs) do
+        (rand(10) + 1).times.map { build(:job, min_nodes: 1, partition: partition) }
+      end
+      let(:job) { jobs.sample }
+      before { jobs.each { |j| job_registry.add(j) } }
+
+      context 'after completing an allocated job' do
+        before do
+          subject.allocate_jobs
+          job.state = 'COMPLETED'
+        end
+
+        it 'does not appear in the queue' do
+          expect(subject.queue).not_to include(job)
+        end
+      end
+    end
+
+    context 'with a single allocated array job with an execess of tasks' do
+      let(:max_index) { nodes.length + 1 + rand(10) }
+      let(:job) do
+        build(:job, array: "1-#{max_index}", partition: partition, min_nodes: 1)
+      end
+
+      before do
+        job_registry.add(job)
+        subject.allocate_jobs
+      end
+
+      context 'after completing and removing the allocated ARRAY_JOB' do
+        before do
+          job_registry.tasks_for(job).each do |task|
+            task.state = 'COMPLETED'
+            allocation = FlightScheduler.app.allocations.for_job(task)
+            if allocation
+              allocation.nodes.each do |node|
+                FlightScheduler.app.allocations.deallocate_node_from_job(task.id, node.name)
+              end
+            end
+          end
+          job.state = 'COMPLETED'
+          job_registry.remove_old_jobs
+        end
+
+        it 'does not appear in the queue' do
+          expect(subject.queue).to be_empty
+        end
+      end
+
+      context 'after removing an ARRAY_TASK' do
+        let(:task) do
+          subject.queue[0..-2].sample
+        end
+        let(:other_tasks) { subject.queue[0..-2] - [task] }
+
+        before do
+          expect(task.job_type).to eq('ARRAY_TASK')
+          other_tasks # Ensure other_tasks is initialized
+          task.state = 'COMPLETED'
+        end
+
+        it 'includes the main job and other tasks in the queue' do
+          expect(subject.queue).to contain_exactly(job, *other_tasks)
+        end
+
+        it 'does not include the task in the queue' do
+          expect(subject.queue).not_to include(task)
+        end
+      end
+
+      context 'after completing all ARRAY_TASKs' do
+        before do
+          subject.queue.dup.each do |job|
+            next unless job.job_type == 'ARRAY_TASK'
+            job.state = 'COMPLETED'
+          end
+        end
+
+        it 'only includes the main job in the queue' do
+          expect(subject.queue).to contain_exactly(job)
+        end
+      end
+    end
+
+    context 'with a single allocated array job with parity between tasks and nodes' do
+      let(:job) do
+        build(:job, array: "1-#{nodes.length}", partition: partition, min_nodes: 1)
+      end
+
+      before do
+        job_registry.add(job)
+        subject.allocate_jobs
+      end
+
+      context 'after completing all the tasks' do
+        before do
+          subject.queue.dup.each do |job|
+            next unless job.job_type == 'ARRAY_TASK'
+            job.state = 'COMPLETED'
+          end
+        end
+
+        it 'removes the main job' do
+          expect(subject.queue).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds a very simple, conservative backfilling scheduler.

When a job cannot be allocated, the scheduler determines the shortage of nodes.  It then determines if there will be an excess of nodes when the a currently allocated job is deallocated.  If there will be an excess of nodes regardless of which job is deallocated, that excess can be used for backfilling.  The minimum excess nodes is selected for backfilling.

If multiple jobs are skipped, any backfilled job must not delay any of those jobs.

The jobs' max runtime is currently not considered in this algorithm.  This results in the backfilling being a lot more conservative than one that would include the jobs' max runtime.  Support for considering runtime will be added in future iterations.