### PR TITLE
Finalise multiple partitions

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -390,5 +390,14 @@ class App < Sinatra::Base
       FlightScheduler.app.event_processor.cancel_job(resource)
       nil
     end
+
+    has_one :partition do
+      graft(sideload_on: :create) do |rio|
+        # This could set the partition to `nil`.  This intended, the job
+        # validation will pickup on this and report a suitable error message.
+        partition = FlightScheduler.app.partitions.detect { |p| p.name == rio[:id] }
+        resource.partition = partition
+      end
+    end
   end
 end

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -84,6 +84,12 @@
 # Default: backfilling
 # scheduler_algorithm: backfilling
 
+# Maximum number of jobs to consider when running the scheduling loop.
+# Environment variable FLIGHT_SCHEDULER_SCHEDULER_MAX_JOBS_CONSIDERED takes
+# precedence over this setting.
+# Default: backfilling
+# scheduler_max_jobs_considered: 50
+
 # Partitions.
 partitions:
   - name: all

--- a/lib/flight_scheduler/configuration.rb
+++ b/lib/flight_scheduler/configuration.rb
@@ -91,6 +91,11 @@ module FlightScheduler
         env_var: true,
         default: 'backfilling',
       },
+      {
+        name: :scheduler_max_jobs_considered,
+        env_var: true,
+        default: 50,
+      },
     ]
     attr_accessor(*ATTRIBUTES.map { |a| a[:name] })
 

--- a/lib/flight_scheduler/schedulers/base_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/base_scheduler.rb
@@ -1,0 +1,146 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+# Abstract base class for schedulers.
+class BaseScheduler
+  class InvalidJobType < RuntimeError; end
+
+  def initialize
+    @allocation_mutex = Mutex.new
+  end
+
+  def queue
+    # For some schedulers, the queue is a sorted and slightly filtered view of
+    # the registry of jobs.
+    #
+    # The sorting and filtering is primarily intended for display purposes,
+    # but also using it for processing ensures that the jobs are processed in
+    # the order in which the queue output suggests.
+    #
+    # The jobs are sorted to ensure that running jobs are placed higher in the
+    # queue output than pending jobs.
+    #
+    # The jobs are filtered to ensure that array jobs without any pending
+    # tasks are not included.
+    #
+    # A more complicated scheduler may implement a priority queue and need to
+    # keep its own record of the queued jobs rather than using the job
+    # registry.
+    running_jobs_first = lambda { |job| job.reason_pending.nil? ? -1 : 1 }
+
+    # NOTE: We rely on the sort being stable to ensure that earlier added jobs
+    # are considered prior to later added jobs.
+    FlightScheduler.app.job_registry.jobs
+      .reject { |j| j.job_type == 'ARRAY_JOB' && j.task_generator.finished? }
+      .reject { |j| j.terminal_state? }
+      .sort_by.with_index { |x, idx| [running_jobs_first.call(x), idx] }
+  end
+
+  private
+
+  # Attempt to allocate a single job.
+  #
+  # If the partition has sufficient resources available for the job, a
+  # new +Allocation+ is added to the allocations registry and returned.
+  #
+  # If an allocation is created for an `ARRAY_TASK`, it is added to the job
+  # registry and the associated task generator advanced.
+  #
+  # If there are insufficient resources available to allocate to the job,
+  # the job's `reason_pending` is updated and +nil+ is returned.
+  def allocate_job(job, reason: 'Resources')
+    raise InvalidJobType, job if job.job_type == 'ARRAY_JOB'
+
+    # Generate an allocation for the job
+    nodes = job.partition.nodes
+    FlightScheduler::LoadBalancer.new(job: job, nodes: nodes).allocate.tap do |allocation|
+      if allocation.nil?
+        if job.job_type == 'ARRAY_TASK'
+          job.array_job.reason_pending = reason
+        else
+          job.reason_pending = reason
+        end
+        nil
+      else
+        if job.job_type == 'ARRAY_TASK'
+          FlightScheduler.app.job_registry.add(job)
+          job.array_job.task_generator.advance_next_task
+        end
+        FlightScheduler.app.allocations.add(allocation)
+      end
+    end
+  end
+
+  # Return an enumerator that yields candidate jobs from the queue.
+  #
+  # The jobs on the queue are considered in turn.  If it is a JOB it is
+  # yielded.
+  #
+  # If it is an ARRAY_JOB, its ARRAY_TASKs are yielded until either they are
+  # exhausted or the yielded ARRAY_TASK is not allocated resources.
+  def candidates
+    # The maximum number of queued jobs to consider.
+    max_jobs_to_consider = 50
+    considered = 0
+
+    Enumerator.new do |yielder|
+      queue.each do |job|
+        considered += 1
+        if considered > max_jobs_to_consider
+          break
+        end
+        next unless job.pending? && job.allocation.nil?
+        max_time_limit = job.partition.max_time_limit
+        if max_time_limit && job.time_limit.nil? || job.time_limit > max_time_limit
+          job.reason_pending = 'PartitionTimeLimit'
+          next
+        end
+
+        if job.job_type == 'ARRAY_JOB'
+          previous_task = nil
+          loop do
+            next_task = job.task_generator.next_task
+            if next_task == previous_task
+              # We failed to schedule the ARRAY_TASK.  Move onto the next
+              # ARRAY_JOB or JOB.
+              break
+            elsif next_task.nil?
+              # We've exhausted the ARRAY_JOB.  Move onto the next ARRAY_JOB
+              # or JOB.
+              break
+            else
+              previous_task = next_task
+              yielder << next_task
+            end
+          end
+        else
+          yielder << job
+        end
+      end
+    end
+  end
+end

--- a/spec/schedulers/shared_scheduler_spec.rb
+++ b/spec/schedulers/shared_scheduler_spec.rb
@@ -40,7 +40,9 @@ RSpec.shared_examples 'basic scheduler specs' do
     context 'with the initial empty scheduler' do
       it 'does not create any allocations' do
         expect(scheduler.queue).to be_empty
-        expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
+        expect{
+          scheduler.allocate_jobs(partitions: partitions)
+        }.not_to change { allocations.size }
       end
     end
 
@@ -54,7 +56,9 @@ RSpec.shared_examples 'basic scheduler specs' do
       }
 
       it 'does not create any allocations' do
-        expect{ scheduler.allocate_jobs }.not_to change { allocations.size }
+        expect{
+          scheduler.allocate_jobs(partitions: partitions)
+        }.not_to change { allocations.size }
       end
     end
 
@@ -69,7 +73,9 @@ RSpec.shared_examples 'basic scheduler specs' do
       }
 
       it 'creates an allocation for each job' do
-        expect{ scheduler.allocate_jobs }.to change { allocations.size }.by(number_jobs)
+        expect{
+          scheduler.allocate_jobs(partitions: partitions)
+        }.to change { allocations.size }.by(number_jobs)
       end
     end
   end
@@ -95,7 +101,7 @@ RSpec.shared_examples '(basic) #queue specs' do
       end
 
       context 'after allocation' do
-        before { subject.allocate_jobs }
+        before { subject.allocate_jobs(partitions: partitions) }
 
         it 'matches the jobs' do
           expect(subject.queue).to eq(jobs)
@@ -115,7 +121,7 @@ RSpec.shared_examples '(basic) #queue specs' do
       end
 
       context 'after allocation' do
-        before { subject.allocate_jobs }
+        before { subject.allocate_jobs(partitions: partitions) }
 
         it 'does not contain the main job' do
           expect(subject.queue).not_to include(job)
@@ -146,7 +152,7 @@ RSpec.shared_examples '(basic) #queue specs' do
       end
 
       context 'after allocation' do
-        before { subject.allocate_jobs }
+        before { subject.allocate_jobs(partitions: partitions) }
 
         it 'contains the main job in the last position' do
           expect(subject.queue.last).to eq(job)
@@ -178,7 +184,7 @@ RSpec.shared_examples '(basic) job completion or cancellation specs' do
 
       context 'after completing an allocated job' do
         before do
-          subject.allocate_jobs
+          subject.allocate_jobs(partitions: partitions)
           job.state = 'COMPLETED'
         end
 
@@ -196,7 +202,7 @@ RSpec.shared_examples '(basic) job completion or cancellation specs' do
 
       before do
         job_registry.add(job)
-        subject.allocate_jobs
+        subject.allocate_jobs(partitions: partitions)
       end
 
       context 'after completing and removing the allocated ARRAY_JOB' do
@@ -261,7 +267,7 @@ RSpec.shared_examples '(basic) job completion or cancellation specs' do
 
       before do
         job_registry.add(job)
-        subject.allocate_jobs
+        subject.allocate_jobs(partitions: partitions)
       end
 
       context 'after completing all the tasks' do


### PR DESCRIPTION
This PR adds support for jobs using a non-default partition and for the scheduling of partitions to be considered separately.

Common code for the schedulers have been extracted to a base class.  I'm confident that they are now sufficiently well understood for this to be the right time.

When attempting to allocate resources to a job, we iterate over the partitions in the order that they are defined on the config file.  We consider only jobs for the current partition.  When a job on the current partition cannot be scheduled we ignore any more jobs on that partition and move onto the next partition.

Also a couple of comments from #40 have been addressed.