### PR TITLE
Use an environment specific config path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /log
 /vendor
 tags
+etc/flight-scheduler-controller.development.yaml
 
 # NOTE: This is a general ignore all yaml files in the config directory
 # There are a couple of configs which have manually be checked in

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 /log
 /vendor
 tags
-etc/flight-scheduler-controller.development.yaml
+etc/flight-scheduler-controller.*.local.yaml
 
 # NOTE: This is a general ignore all yaml files in the config directory
 # There are a couple of configs which have manually be checked in

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -25,6 +25,8 @@
 # https://github.com/openflighthpc/flight-scheduler-controller
 #==============================================================================
 
+ENV['RACK_ENV'] ||= 'development'
+
 lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/etc/flight-scheduler-controller.development.yaml
+++ b/etc/flight-scheduler-controller.development.yaml
@@ -1,0 +1,47 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+auth_type: "basic"
+bind_address: "http://127.0.0.1:6307"
+# cluster_name: ""
+# env_var_prefix: ""
+log_level: debug
+# polling_timeout: 30
+# spool_dir: './var/spool'
+# timer_interval: 60
+# timer_timeout: 30
+# scheduler_algorithm: backfilling
+# scheduler_max_jobs_considered: 50
+
+partitions:
+  - name: all
+    default: true
+    max_time_limit: 10
+    default_time_limit: 1
+    node_matches:
+      name:
+        regex: ".*"

--- a/etc/flight-scheduler-controller.test.yaml
+++ b/etc/flight-scheduler-controller.test.yaml
@@ -1,0 +1,35 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+partitions:
+  - name: all
+    default: true
+    max_time_limit: 10
+    default_time_limit: 1
+    node_matches:
+      name:
+        regex: ".*"

--- a/lib/flight_scheduler/configuration.rb
+++ b/lib/flight_scheduler/configuration.rb
@@ -106,9 +106,11 @@ module FlightScheduler
       if ENV['RACK_ENV'] == 'production'
         Loader.new(root, root.join(PRODUCTION_PATH)).load
       else
-        path = root.join(PATH_GENERATOR.call(ENV['RACK_ENV']))
-        FileUtils.cp root.join(PRODUCTION_PATH), path unless File.exists? path
-        Loader.new(root, path).load
+        paths = [
+          root.join(PATH_GENERATOR.call(ENV['RACK_ENV'])),
+          root.join(PATH_GENERATOR.call("#{ENV['RACK_ENV']}.local")),
+        ]
+        Loader.new(root, paths).load
       end
     end
 

--- a/lib/flight_scheduler/configuration/loader.rb
+++ b/lib/flight_scheduler/configuration/loader.rb
@@ -59,6 +59,7 @@ module FlightScheduler
 
       def from_config_file
         if @config_file.exist?
+          Async.logger.info "LOADING CONFIG: #{@config_file}"
           ( YAML.load_file(@config_file) || {} ).deep_transform_keys(&:to_s)
         else
           raise "Could not load configuration. No such file - #{@config_file}"


### PR DESCRIPTION
This allows a different set of partitions to be used in development without affecting the production config.

This will require future production builds to set `RACK_ENV=production`, however this should probably be done anyway.