### PR TITLE
Allow nodes to be categorised by type

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -68,6 +68,11 @@ class Node
     @attributes = attributes || NodeAttributes.new(cpus: 1, memory: 1048576)
   end
 
+  # TODO: Allow the daemon to set me!
+  def type
+    'unknown'
+  end
+
   def state
     if allocations.any?
       'ALLOC'

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -38,11 +38,17 @@ class Node
 
     DELEGATES = [:cpus, :gpus, :memory]
 
+    attr_writer :type
     attr_accessor(*DELEGATES)
     validates(*DELEGATES, allow_nil: true, numericality: { only_integers: true })
 
+    def type
+      str = @type.to_s
+      str.empty? ? 'unknown' : str
+    end
+
     def to_h
-      self.class::DELEGATES.each_with_object({}) do |key, memo|
+      self.class::DELEGATES.each_with_object({ type: type }) do |key, memo|
         memo[key] = self.send(key)
       end
     end
@@ -66,11 +72,6 @@ class Node
   def initialize(name:, attributes: nil)
     @name = name
     @attributes = attributes || NodeAttributes.new(cpus: 1, memory: 1048576)
-  end
-
-  # TODO: Allow the daemon to set me!
-  def type
-    'unknown'
   end
 
   def state

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -63,7 +63,7 @@ class Node
 
   extend Forwardable
   attr_accessor :attributes
-  def_delegators  :attributes, *NodeAttributes::DELEGATES
+  def_delegators  :attributes, :type, *NodeAttributes::DELEGATES
 
   attr_reader :name
 

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -78,7 +78,7 @@ class Partition
   end
 
   validate do
-    types.each do |type|
+    types.each do |_, type|
       next if type.minimum.nil? || type.maximum.nil?
       next if type.minimum <= type.maximum
       @errors.add(:type_minimum, 'must be less than or equal to the maximum')
@@ -157,8 +157,8 @@ class Partition
 
   def types
     @types ||= @types_spec.map do |name, spec|
-      Type.new(self, name, spec['minimum'], spec['maximum'])
-    end
+      [name, Type.new(self, name, spec['minimum'], spec['maximum'])]
+    end.to_h
   end
 
   def ==(other)

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -29,6 +29,12 @@ require_relative './partition/builder'
 require_relative './partition/script_runner'
 
 class Partition
+  Type = Struct.new(:partition, :name, :minimum, :maximum) do
+    def nodes
+      partition.nodes.select { |n| n.type == name }
+    end
+  end
+
   include ActiveModel::Validations
 
   attr_reader :name, :nodes, :max_time_limit, :default_time_limit
@@ -78,6 +84,7 @@ class Partition
     default_time_limit_spec: nil,
     max_time_limit_spec: nil,
     node_matchers_spec: nil,
+    types_spec: nil,
     excess_script: nil,
     insufficient_script: nil,
     status_script: nil
@@ -87,6 +94,7 @@ class Partition
     @max_time_limit_spec = max_time_limit_spec
     @default_time_limit_spec = default_time_limit_spec
     @node_matchers_spec = node_matchers_spec
+    @types_spec = types_spec || {}
     @static_node_names = static_node_names || []
     @excess_script    = excess_script
     @insufficient_script  = insufficient_script
@@ -137,6 +145,12 @@ class Partition
 
   def default?
     !!@default
+  end
+
+  def types
+    @types ||= @types_spec.map do |name, spec|
+      Type.new(self, name, spec['minimum'], spec['maximum'])
+    end
   end
 
   def ==(other)

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -77,6 +77,14 @@ class Partition
     @errors.add(:max_time_limit_spec, 'must be greater than or equal the default')
   end
 
+  validate do
+    types.each do |type|
+      next if type.minimum.nil? || type.maximum.nil?
+      next if type.minimum <= type.maximum
+      @errors.add(:type_minimum, 'must be less than or equal to the maximum')
+    end
+  end
+
   def initialize(
     name:,
     default: false,

--- a/app/models/partition/builder.rb
+++ b/app/models/partition/builder.rb
@@ -77,7 +77,7 @@ class Partition
       }
     }
 
-    SPEC_KEYS   = ['max_time_limit', 'default_time_limit', 'node_matchers']
+    SPEC_KEYS   = ['max_time_limit', 'default_time_limit', 'node_matchers', 'types']
     OTHER_KEYS  = ['default', 'name']
     VALIDATOR = JSONSchemer.schema(ROOT_SCHEMA)
 

--- a/app/models/partition/builder.rb
+++ b/app/models/partition/builder.rb
@@ -47,6 +47,22 @@ class Partition
             "insufficient" => { "type" => "string" },
             "status" => { "type" => "string" }
           }
+        },
+        "types" => {
+          "type" => "object",
+          "properties" => {
+            "unknown" => { "type" => "null" }
+          },
+          "patternProperties" => {
+            ".*" => {
+              "type" => "object",
+              "additionalProperties" => false,
+              "properties" => {
+                "minimum" => { "type" => "integer" },
+                "maximum" => { "type" => "integer" }
+              }
+            }
+          }
         }
       }
     }

--- a/app/websocket_app.rb
+++ b/app/websocket_app.rb
@@ -91,6 +91,7 @@ class WebsocketApp
     property :cpus,   type: :integer, required: false
     property :gpus,   type: :integer, required: false
     property :memory, type: :integer, required: false
+    property :type,   type: :string,  required: false
   end
 
   swagger_schema :nodeCompletedJobWS do
@@ -265,6 +266,7 @@ class WebsocketApp
     attributes.cpus   = message[:cpus]    if message.key?(:cpus)
     attributes.gpus   = message[:gpus]    if message.key?(:gpus)
     attributes.memory = message[:memory]  if message.key?(:memory)
+    attributes.type   = message[:type]    if message.key?(:type)
 
     if attributes == node.attributes
       Async.logger.debug("Unchanged '#{node_name}' attributes:") {

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -118,6 +118,8 @@ partitions:
     #   excess: demo.sh
     #   insufficient: demo.sh
     #   status: demo.sh
+    types:
+      foobar: {}
     node_matchers:
       name:
         regex: ".*"

--- a/lib/flight_scheduler/schedulers/base_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/base_scheduler.rb
@@ -137,7 +137,9 @@ class BaseScheduler
       queue(partition).each do |job|
         next unless job.pending? && job.allocation.nil?
         max_time_limit = job.partition.max_time_limit
-        if max_time_limit && job.time_limit.nil? || job.time_limit > max_time_limit
+        if max_time_limit.nil?
+          # NOOP
+        elsif job.time_limit.nil? || job.time_limit > max_time_limit
           job.reason_pending = 'PartitionTimeLimit'
           next
         end


### PR DESCRIPTION
Each partition can optionally define a list of node `types`. Each type can then define the `maximum` and `minimum` number allowed. These limits are not enforced by the scheduler, but instead are serialized into the `event_scripts` standard input.

This allows the `oversubscribed` and `oversubscribed` `event_script` flags to be set. It is up to the scripts to determine how to respond. In addition to this, the full `nodes` information is now provided to the events scripts.

The daemon can set the node type when it connects. Otherwise the node type defaults to `unknown`.

Based on #42 