### PR TITLE
Refactor the STDIN input to event scripts and add slack integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /vendor
 tags
 etc/flight-scheduler-controller.*.local.yaml
+libexec/.slackrc
 
 # NOTE: This is a general ignore all yaml files in the config directory
 # There are a couple of configs which have manually be checked in

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 /vendor
 tags
 etc/flight-scheduler-controller.*.local.yaml
-libexec/.slackrc
+libexec/slackrc
 
 # NOTE: This is a general ignore all yaml files in the config directory
 # There are a couple of configs which have manually be checked in

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -67,7 +67,7 @@ class Node
 
   attr_reader :name
 
-  STATES = ['IDLE', 'ALLOC']
+  STATES = ['IDLE', 'ALLOC', 'DOWN']
 
   def initialize(name:, attributes: nil)
     @name = name

--- a/app/models/partition/script_runner.rb
+++ b/app/models/partition/script_runner.rb
@@ -123,6 +123,7 @@ class Partition
         # These other jobs are not serialized to provide a limit on the data provided
         # to the script. Instead the other job ids are provided separately
         jobs, others = FlightScheduler.app.allocations.for_node(node.name)
+                                      .map(&:job)
                                       .partition { |j| j.partition == partition }
 
         [node.name, {

--- a/app/models/partition/script_runner.rb
+++ b/app/models/partition/script_runner.rb
@@ -196,7 +196,7 @@ class Partition
       Async.logger.info "Running (#{type}): #{path}"
       stdin_str = JSON.pretty_generate(stdin(type))
       Async.logger.debug("STDIN:") { stdin_str }
-      out, err, status = Open3.capture3(path, stdin_data: stdin_str,
+      out, err, status = Open3.capture3({ 'PATH' => ENV['PATH'] }, path, stdin_data: stdin_str,
         close_others: true, unsetenv_others: true, chdir: FlightScheduler.app.config.libexec_dir)
       msg = <<~MSG
         COMMAND (#{type}): #{path}

--- a/app/models/partition/script_runner.rb
+++ b/app/models/partition/script_runner.rb
@@ -138,11 +138,12 @@ class Partition
     end
 
     def build_type_hash(type_name, nodes)
-      count = nodes.length
+      count = nodes.reject { |n| n.state == 'DOWN' }.length
       base = {
         name: type_name,
         nodes: nodes.map(&:name),
         count: count,
+        known_count: nodes.length
       }
       if type = partition.types[type_name]
         base.merge!(recognized: true)

--- a/app/models/partition/script_runner.rb
+++ b/app/models/partition/script_runner.rb
@@ -1,5 +1,5 @@
 #==============================================================================
-# Copyright (C) 2020-present Alces Flight Ltd.
+# Copyright (C) 2021-present Alces Flight Ltd.
 #
 # This file is part of FlightSchedulerController.
 #

--- a/app/models/partition/script_runner.rb
+++ b/app/models/partition/script_runner.rb
@@ -126,11 +126,6 @@ class Partition
         end.to_h,
         types: all_types,
         jobs: jobs_hash,
-        alloc_nodes: nodes.select { |n| n.state == 'ALLOC' }.map(&:name),
-        idle_nodes: nodes.select { |n| n.state == 'IDLE' }.map(&:name),
-        down_nodes: nodes.select { |n| n.state == 'DOWN' }.map(&:name),
-        pending_jobs: pending_jobs.map(&:id),
-        resource_jobs: resource_jobs.map(&:id),
         pending_aggregate: aggregate_jobs(*pending_jobs),
         resource_aggregate: aggregate_jobs(*resource_jobs)
       }

--- a/app/models/partition/script_runner.rb
+++ b/app/models/partition/script_runner.rb
@@ -180,13 +180,13 @@ class Partition
         memory_per_node: jobs.map(&:memory_per_node).max,
         nodes_per_job: jobs.map(&:min_nodes).max,
         exclusive_nodes_count: jobs.select(&:exclusive).map(&:min_nodes).reduce(&:+),
-        shared_cpus_count: jobs.reject(&:exclusive).map do |job|
+        cpus_count: jobs.map do |job|
           job.min_nodes * job.cpus_per_node
         end.reduce(&:+),
-        shared_gpus_count: jobs.reject(&:exclusive).map do |job|
+        gpus_count: jobs.map do |job|
           job.min_nodes * job.gpus_per_node
         end.reduce(&:+),
-        shared_memory_count: jobs.reject(&:exclusive).map do |job|
+        memory_count: jobs.map do |job|
           job.min_nodes * job.memory_per_node
         end.reduce(&:+)
       }

--- a/libexec/slack.sh
+++ b/libexec/slack.sh
@@ -122,7 +122,7 @@ read -r -d '' template <<'TEMPLATE' || true
       ]
     }))[],
     {
-      pretext: "Overall Cluster Status",
+      pretext: "Overall Partition Status",
       fields: [
         { short: true, title: "Total Nodes", value: (.nodes | length) }
       ]

--- a/libexec/slack.sh
+++ b/libexec/slack.sh
@@ -69,7 +69,7 @@ read -r -d '' template <<'TEMPLATE' || true
 {
   channel: ($channel),
   as_user: true,
-  text: ("Scheduler Update: `\(.action)` nodes"),
+  text: ("Scheduler Update (`\(.partition)`): `\(.action)` nodes"),
   attachments: [
     {
       pretext: "Summary of jobs which are blocked due to insufficient `resources`:",

--- a/libexec/slack.sh
+++ b/libexec/slack.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e
+
+source ~/.secretrc
+
+read -r -d '' template <<'TEMPLATE' || true
+{
+  channel: "workshop",
+  as_user: true,
+  text: ("Scheduler Update: `" + .action + "` nodes"),
+  attachments: [
+    {
+      pretext: "Summary of jobs which are blocked due to insufficient `resources`:",
+      fields: [
+        { short: true, title: "*Number of Jobs*", "value": (.resource_jobs | length) },
+        { short: true, title: "*Number of Exclusive Nodes*", "value": .resource_aggregate.exclusive_nodes_count },
+        { short: true, title: "*Max Requested Nodes per Job*", "value": .resource_aggregate.nodes_per_job },
+        { short: true, title: "*Max Requested CPUs per Node*", "value": .resource_aggregate.cpus_per_node },
+        { short: true, title: "*Max Requested GPUs per Node*", "value": .resource_aggregate.gpus_per_node },
+        { short: true, title: "*Max Requested Memory per Node*", "value": .resource_aggregate.exclusive_nodes_count },
+        { short: true, title: "*Total Required CPUs*", "value": .resource_aggregate.cpus_count },
+        { short: true, title: "*Total Required GPUs*", "value": .resource_aggregate.gpus_count },
+        { short: true, title: "*Total Required Memory*", "value": .resource_aggregate.memory_count }
+      ]
+    },
+    {
+      pretext: "Summary of all `pending` jobs:",
+      fields: [
+        { short: true, title: "*Number of Jobs*", "value": (.pending_jobs | length) },
+        { short: true, title: "*Number of Exclusive Nodes*", "value": .pending_aggregate.exclusive_nodes_count },
+        { short: true, title: "*Max Requested Nodes per Job*", "value": .pending_aggregate.nodes_per_job },
+        { short: true, title: "*Max Requested CPUs per Node*", "value": .pending_aggregate.cpus_per_node },
+        { short: true, title: "*Max Requested GPUs per Node*", "value": .pending_aggregate.gpus_per_node },
+        { short: true, title: "*Max Requested Memory per Node*", "value": .pending_aggregate.exclusive_nodes_count },
+        { short: true, title: "*Total Required CPUs*", "value": .pending_aggregate.cpus_count },
+        { short: true, title: "*Total Required GPUs*", "value": .pending_aggregate.gpus_count },
+        { short: true, title: "*Total Required Memory*", "value": .pending_aggregate.memory_count }
+      ]
+    },
+    {
+      pretext: "Overall Cluster Status",
+      fields: [
+        { short: true, title: "Total Nodes", value: (.nodes | length) },
+        { short: true, title: "Total CPUs", value: ([.nodes[].cpus] | add) },
+        { short: true, title: "Total GPUs", value: ([.nodes[].gpus] | add) },
+        { short: true, title: "Total Memory", value: ([.nodes[].memory] | add) },
+        { short: true, title:  }
+      ]
+    }
+  ]
+}
+TEMPLATE
+
+payload=$(jq "$template" <&0)
+echo $payload
+
+curl -v -H 'Content-Type: application/json; charset=UTF-8' \
+                  -H "Authorization: Bearer $SLACK_TOKEN" \
+                  -d @- \
+                  "https://slack.com/api/chat.postMessage" \
+                  2>/dev/null <<< $payload

--- a/libexec/slack.sh
+++ b/libexec/slack.sh
@@ -69,7 +69,7 @@ read -r -d '' template <<'TEMPLATE' || true
 {
   channel: ($channel),
   as_user: true,
-  text: ("Scheduler Update: `" + .action + "` nodes"),
+  text: ("Scheduler Update: `\(.action)` nodes"),
   attachments: [
     {
       pretext: "Summary of jobs which are blocked due to insufficient `resources`:",

--- a/libexec/slack.sh
+++ b/libexec/slack.sh
@@ -99,6 +99,28 @@ read -r -d '' template <<'TEMPLATE' || true
         { short: true, title: "*Pending Jobs*", "value": ($pending | length) }
       ]
     },
+    (.types | to_entries | map({
+      pretext: "Summary of `\(.key)` Node Type",
+      fields: [
+        { short: true, title: "*Number of Nodes*", "value": .value.count},
+        { short: true, title: "*Min/Max Nodes*", "value": "\(.value.minimum)/\(.value.maximum)"},
+        { short: true, title: "*Status*", value: (
+          if .value.undersubscribed or .value.oversubscribed then
+            if .value.oversubscribed then
+              "Oversubscribed"
+            else
+              "Undersubscribed"
+            end
+          else
+            if .value.recognized then
+              "OK"
+            else
+              "Unrecognized"
+            end
+          end)
+        }
+      ]
+    }))[],
     {
       pretext: "Overall Cluster Status",
       fields: [

--- a/libexec/slack.sh
+++ b/libexec/slack.sh
@@ -32,7 +32,7 @@ which "jq" >/dev/null
 
 # Load the .slackrc file which is within the working directory. By default this will be
 # the directory containing this file, however this may change depending on configuration
-rc="./.slackrc"
+rc="./slackrc"
 if [[ -f "$rc" ]]; then
   source "$rc"
 else

--- a/libexec/slack.sh
+++ b/libexec/slack.sh
@@ -1,8 +1,39 @@
 #!/bin/bash
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
 
 set -e
 
 source ~/.secretrc
+
+json=$(cat <&0)
+running=$(echo "$json" | jq '.jobs | with_entries(select(.value | .state == "RUNNING"))')
+pending=$(echo "$json" | jq '.jobs | with_entries(select(.value | .state == "PENDING"))')
+resources=$(echo "$json" | jq '.jobs | with_entries(select(.value | .reason == "Resources"))')
 
 read -r -d '' template <<'TEMPLATE' || true
 {
@@ -13,50 +44,51 @@ read -r -d '' template <<'TEMPLATE' || true
     {
       pretext: "Summary of jobs which are blocked due to insufficient `resources`:",
       fields: [
-        { short: true, title: "*Number of Jobs*", "value": (.resource_jobs | length) },
-        { short: true, title: "*Number of Exclusive Nodes*", "value": .resource_aggregate.exclusive_nodes_count },
-        { short: true, title: "*Max Requested Nodes per Job*", "value": .resource_aggregate.nodes_per_job },
-        { short: true, title: "*Max Requested CPUs per Node*", "value": .resource_aggregate.cpus_per_node },
-        { short: true, title: "*Max Requested GPUs per Node*", "value": .resource_aggregate.gpus_per_node },
-        { short: true, title: "*Max Requested Memory per Node*", "value": .resource_aggregate.exclusive_nodes_count },
-        { short: true, title: "*Total Required CPUs*", "value": .resource_aggregate.cpus_count },
-        { short: true, title: "*Total Required GPUs*", "value": .resource_aggregate.gpus_count },
-        { short: true, title: "*Total Required Memory*", "value": .resource_aggregate.memory_count }
+        { short: true, title: "*Number of Jobs*", "value": ($resources | length) },
+        { short: true, title: "*Max Requested Nodes per Job*", "value": ([$resources[].min_nodes] | max) },
+        { short: true, title: "*Max Requested CPUs per Node*", "value": ([$resources[].cpus_per_node] | max) },
+        { short: true, title: "*Max Requested GPUs per Node*", "value": ([$resources[].gpus_per_node] | max) },
+        { short: true, title: "*Max Requested Memory per Node*", "value": ([$resources[].memory_per_node] | max) }
       ]
     },
     {
       pretext: "Summary of all `pending` jobs:",
       fields: [
-        { short: true, title: "*Number of Jobs*", "value": (.pending_jobs | length) },
-        { short: true, title: "*Number of Exclusive Nodes*", "value": .pending_aggregate.exclusive_nodes_count },
-        { short: true, title: "*Max Requested Nodes per Job*", "value": .pending_aggregate.nodes_per_job },
-        { short: true, title: "*Max Requested CPUs per Node*", "value": .pending_aggregate.cpus_per_node },
-        { short: true, title: "*Max Requested GPUs per Node*", "value": .pending_aggregate.gpus_per_node },
-        { short: true, title: "*Max Requested Memory per Node*", "value": .pending_aggregate.exclusive_nodes_count },
-        { short: true, title: "*Total Required CPUs*", "value": .pending_aggregate.cpus_count },
-        { short: true, title: "*Total Required GPUs*", "value": .pending_aggregate.gpus_count },
-        { short: true, title: "*Total Required Memory*", "value": .pending_aggregate.memory_count }
+        { short: true, title: "*Number of Jobs*", "value": ($pending | length) },
+        { short: true, title: "*Max Requested Nodes per Job*", "value": ([$pending[].min_nodes] | max) },
+        { short: true, title: "*Max Requested CPUs per Node*", "value": ([$pending[].cpus_per_node] | max) },
+        { short: true, title: "*Max Requested GPUs per Node*", "value": ([$pending[].gpus_per_node] | max) },
+        { short: true, title: "*Max Requested Memory per Node*", "value": ([$pending[].memory_per_node] | max) }
+      ]
+    },
+    {
+      pretext: "Summary of all jobs:",
+      fields: [
+        { short: true, title: "*Total Jobs*", "value": (.jobs | length) },
+        { short: true, title: "*Running Jobs*", "value": ($running | length) },
+        { short: true, title: "*Pending Jobs*", "value": ($pending | length) }
       ]
     },
     {
       pretext: "Overall Cluster Status",
       fields: [
-        { short: true, title: "Total Nodes", value: (.nodes | length) },
-        { short: true, title: "Total CPUs", value: ([.nodes[].cpus] | add) },
-        { short: true, title: "Total GPUs", value: ([.nodes[].gpus] | add) },
-        { short: true, title: "Total Memory", value: ([.nodes[].memory] | add) },
-        { short: true, title:  }
+        { short: true, title: "Total Nodes", value: (.nodes | length) }
       ]
     }
   ]
 }
 TEMPLATE
 
-payload=$(jq "$template" <&0)
-echo $payload
+payload=$( echo "$json" | jq \
+  --argjson root "$json" \
+  --argjson running "$running" \
+  --argjson pending "$pending" \
+  --argjson resources "$resources" \
+  "$template"
+)
 
 curl -v -H 'Content-Type: application/json; charset=UTF-8' \
-                  -H "Authorization: Bearer $SLACK_TOKEN" \
-                  -d @- \
-                  "https://slack.com/api/chat.postMessage" \
-                  2>/dev/null <<< $payload
+  -H "Authorization: Bearer $SLACK_TOKEN" \
+  -d @- \
+  "https://slack.com/api/chat.postMessage" \
+  2>/dev/null <<< $payload

--- a/libexec/slackrc.example
+++ b/libexec/slackrc.example
@@ -1,0 +1,9 @@
+# =============================================================================
+# The following contains the required keys for the slack.sh script.
+# Please copy this file into place and set the environment variable
+#
+# $ cp /path/to/slackrc.example /path/to/slackrc
+# =============================================================================
+
+SLACK_TOKEN=    # The slack bot API token, must be able to post as a user
+SLACK_CHANNEL=  # The channel (or channels) id or name to post to


### PR DESCRIPTION
This work is based on #44

The standard input to the event scripts has been refactored as it proved difficult to use with `jq`. In particular the following has been removed:
* The arrays of `pending`/`resources` job ids as it duplicates the `jobs` hash. Cross referencing proved to be trickier than filtering,
* The arrays of node names by state for a similar reason above, and
* The aggregation objects as they where both unclear and incomplete.

Instead the responsibility for filtering and aggregating the `jobs`/`nodes` has been moved to the script. Whilst this does increase the burden on the script writer, it also provides maximum clarity and flexibility.

To ease the getting started pressure, a demo slack integration script has been added. It uses `jq` to preform the json manipulation and generate the slack payload.