### PR TITLE
Backfilling scheduler part 2

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -70,7 +70,7 @@ class Job
       end
 
     # Attributes copied directly from the persisted state.
-    attr_names = %w(array array_index id job_type min_nodes reason_pending state username time_limit_spec)
+    attr_names = %w(array array_index id job_type min_nodes reason_pending state start_time username time_limit_spec)
     attrs = hash.stringify_keys.slice(*attr_names)
 
     new(array_job: array_job, partition: partition, **attrs).tap do |job|
@@ -104,6 +104,7 @@ class Job
   attr_accessor :state
   attr_accessor :username
   attr_accessor :time_limit_spec
+  attr_accessor :start_time
 
   attr_writer :reason_pending
 
@@ -230,6 +231,7 @@ class Job
       job_type: nil,
       min_nodes: nil,
       reason_pending: nil,
+      start_time: nil,
       state: nil,
       time_limit_spec: nil,
       username: nil,
@@ -352,6 +354,12 @@ class Job
     else
       partition.default_time_limit
     end
+  end
+
+  def end_time
+    return nil if start_time.nil?
+    return nil if time_limit.nil?
+    start_time + time_limit
   end
 
   protected

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -74,6 +74,10 @@ class Job
     attrs = hash.stringify_keys.slice(*attr_names)
 
     new(array_job: array_job, partition: partition, **attrs).tap do |job|
+      start_time = hash.stringify_keys['start_time']
+      if start_time
+        job.start_time = Time.parse(start_time)
+      end
       job.instance_variable_set(:@next_step_id, hash['next_step_id'])
       if hash['batch_script']
         job.batch_script = BatchScript.from_serialized_hash(

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -47,7 +47,13 @@ class Job
   include ActiveModel::Model
   include ActiveModel::Serialization
 
-  PENDING_REASONS = %w( WaitingForScheduling Priority Resources ).freeze
+  PENDING_REASONS = %w(
+    PartitionNodeLimit
+    PartitionTimeLimit
+    Priority
+    Resources
+    WaitingForScheduling
+  ).freeze
   STATES = %w( PENDING RUNNING CANCELLING CANCELLED COMPLETED FAILED TIMINGOUT TIMEOUT ).freeze
   # NOTE: If adding new states to TERMINAL_STATES, `update_array_job_state`
   # will need updating too.

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -103,7 +103,7 @@ class Node
   end
 
   # A static view of whether this node is suitable for the given job.  This
-  # does considers the current state of node but not its allocations.
+  # considers the current state of node but not its allocations.
   def satisfies_job?(job)
     return false if state == 'DOWN'
     key_map = FlightScheduler::AllocationRegistry::KEY_MAP

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -268,7 +268,7 @@ class FlightScheduler::AllocationRegistry
   def considering_allocations(node, given_allocations, excluding_jobs, reservations)
     allocations = nil
     if given_allocations
-      allocations = given_allocations
+      allocations = given_allocations.filter { |r| r.nodes.include? node }
     else
       allocations = @lock.with_read_lock { @node_allocations[node.name] }
     end

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -156,39 +156,16 @@ class FlightScheduler::AllocationRegistry
     values.each(&block)
   end
 
-  def max_parallel_per_node(job, node, excluding_jobs: nil, reservations: nil)
-    # Determine the existing allocations
-    allocations = @lock.with_read_lock { @node_allocations[node.name] }
-    Async.logger.debug("Allocations for #{node.name}") {
-      if allocations.empty?
-        "NONE"
-      else
-        allocations.map { |a| "job=#{a.job.display_id} nodes=#{a.nodes.map(&:name)}" }.join("\n")
-      end
-    }
-    if excluding_jobs
-      excluded_allocations = Array(excluding_jobs).map { |job| for_job(job.id) }
-      allocations -= excluded_allocations.compact
-    end
-    if reservations
-      relevant_reservations = reservations.filter { |r| r.nodes.include? node }
-      Async.logger.debug("Relevant reservations for #{node.name}") {
-        if relevant_reservations.empty?
-          "NONE"
-        else
-          relevant_reservations.map { |a| "job=#{a.job.display_id} nodes=#{a.nodes.map(&:name)}" }.join("\n")
-        end
-      }
-      allocations += Array(relevant_reservations).compact
-    end
-    allocated = allocated_resources(*allocations)
+  def max_parallel_per_node(job, node, allocations: nil, excluding_jobs: nil, reservations: nil)
+    allocs = considering_allocations(node, allocations, excluding_jobs, reservations)
+    allocated = allocated_resources(*allocs)
 
     # Handle jobs with exclusive accesse
-    return 0 if job.exclusive && !allocations.empty?
-    return 0 if allocations.map(&:job).any?(&:exclusive)
+    return 0 if job.exclusive && !allocs.empty?
+    return 0 if allocs.map(&:job).any?(&:exclusive)
 
-    # Determines how many times the job can be ran on the node given its
-    # current allocations.
+    # Determines how many times the job can be ran on the node given the
+    # allocations we're considering.
     max_jobs = KEY_MAP.reduce(nil) do |max, (node_key, job_key)|
       dividor = job.send(job_key).to_i
       next max if dividor < 1
@@ -286,5 +263,38 @@ class FlightScheduler::AllocationRegistry
       @job_allocations.clear
       @node_allocations.clear
     end
+  end
+
+  def considering_allocations(node, given_allocations, excluding_jobs, reservations)
+    allocations = nil
+    if given_allocations
+      allocations = given_allocations
+    else
+      allocations = @lock.with_read_lock { @node_allocations[node.name] }
+    end
+    Async.logger.debug("Allocations for #{node.name}") {
+      if allocations.empty?
+        "NONE"
+      else
+        allocations.map { |a| "job=#{a.job.display_id} nodes=#{a.nodes.map(&:name)}" }.join("\n")
+      end
+    }
+    if excluding_jobs
+      excluded_allocations = Array(excluding_jobs).map { |job| for_job(job.id) }
+      allocations -= excluded_allocations.compact
+    end
+    if reservations
+      relevant_reservations = reservations.filter { |r| r.nodes.include? node }
+      Async.logger.debug("Relevant reservations for #{node.name}") {
+        if relevant_reservations.empty?
+          "NONE"
+        else
+          relevant_reservations.map { |a| "job=#{a.job.display_id} nodes=#{a.nodes.map(&:name)}" }.join("\n")
+        end
+      }
+      allocations += Array(relevant_reservations).compact
+    end
+
+    allocations
   end
 end

--- a/lib/flight_scheduler/array_task_generator.rb
+++ b/lib/flight_scheduler/array_task_generator.rb
@@ -100,6 +100,7 @@ class FlightScheduler::ArrayTaskGenerator
       min_nodes: @job.min_nodes,
       partition: @job.partition,
       state: 'PENDING',
+      time_limit_spec: @job.time_limit_spec,
       username: @job.username,
     )
   end

--- a/lib/flight_scheduler/load_balancer.rb
+++ b/lib/flight_scheduler/load_balancer.rb
@@ -27,10 +27,11 @@
 
 module FlightScheduler
   class LoadBalancer
-    def initialize(job:, nodes:, reservations: nil)
+    def initialize(job:, nodes:, reservations: nil, allocations: nil)
       @job = job
       @nodes = nodes
       @unfilterd_reservations = reservations
+      @allocations = allocations
     end
 
     def allocate
@@ -47,6 +48,7 @@ module FlightScheduler
         max_parallel = FlightScheduler.app.allocations.max_parallel_per_node(
           @job,
           node,
+          allocations: @allocations,
           reservations: reservations,
         )
         [node, max_parallel]

--- a/lib/flight_scheduler/load_balancer.rb
+++ b/lib/flight_scheduler/load_balancer.rb
@@ -27,14 +27,30 @@
 
 module FlightScheduler
   class LoadBalancer
-    def initialize(job:, nodes:)
+    def initialize(job:, nodes:, reservations: nil)
       @job = job
       @nodes = nodes
+      @reservations = reservations
     end
 
     def allocate
+      reservations = reservations()
+      Async.logger.debug("Finding fit for #{@job.display_id}") {
+        if reservations
+          reservation_debug = reservations
+            .map { |a| "job=#{a.job.display_id} start_time=#{a.start_time} nodes=#{a.nodes.map(&:name)}" }
+            .join("\n")
+          "Including reservations\n#{reservation_debug}"
+        end
+      }
+
       sorted = connected_nodes.map do |node|
-        [node, FlightScheduler.app.allocations.max_parallel_per_node(@job, node)]
+        max_parallel = FlightScheduler.app.allocations.max_parallel_per_node(
+          @job,
+          node,
+          reservations: reservations,
+        )
+        [node, max_parallel]
       end
         .reject { |_, count| count == 0 }
         .sort { |(_n1, count1), (_n2, count2)| count1 <=> count2 }
@@ -57,6 +73,22 @@ module FlightScheduler
     end
 
     private
+
+    def reservations
+      return nil if @reservations.nil?
+
+      job_end_time =
+        if @job.end_time
+          @job.end_time
+        elsif @job.time_limit
+          Time.now + @job.time_limit
+        else
+          nil
+        end
+      @reservations.select do |reservation|
+        job_end_time.nil? || reservation.start_time < job_end_time
+      end
+    end
 
     def connected_nodes
       @nodes.select(&:connected?)

--- a/lib/flight_scheduler/schedulers/backfilling_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/backfilling_scheduler.rb
@@ -67,7 +67,7 @@ class BackfillingScheduler < BaseScheduler
       break if candidate.nil?
       Async.logger.debug("Candidate #{candidate.display_id}")
 
-      allocation = allocate_job(candidate)
+      allocation = allocate_job(candidate, reservations: reservations)
       if allocation.nil?
         Async.logger.debug("Unable to allocate candidate. Attempting to backfill.")
         reservation = create_reservation(candidate)

--- a/lib/flight_scheduler/schedulers/backfilling_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/backfilling_scheduler.rb
@@ -38,21 +38,182 @@ class BackfillingScheduler < BaseScheduler
     end
   end
 
-  # Encapsulates when a node will become available to run a particular job.
-  #
-  # `node` is the node.
-  # `jobs` are the jobs which need to complete for it to become available.
-  class NodeAvailability < Struct.new(:node, :jobs)
+  # Determine when `node` will become available to run the `candidate` job.
+  class NodeAvailability < Struct.new(:node, :candidate)
+    # Return the time at which we can guarantee `node` will be available to
+    # run `candidate` or `nil` if no such guarantee is possible.
     def available_at
-      if jobs.empty?
+      if !has_guarantee?
+        nil
+      elsif jobs_waited_on.empty?
         Time.now
       else
-        jobs.map(&:end_time).max
+        jobs_waited_on.map(&:end_time).max
       end
     end
 
+    def has_guarantee?
+      !jobs_waited_on.nil?
+    end
+
+    def has_jobs?
+      !FlightScheduler.app.allocations.for_node(node.name).empty?
+    end
+
+    # If we can determine a set of jobs such that once completed, they will
+    # free up enough resources to run `candidate`, return the earliest
+    # completing set of such jobs.
+    #
+    # If no set of jobs can be determined, return nil.
+    def jobs_waited_on
+      @jobs_waited_on ||=
+        begin
+          if FlightScheduler.app.allocations.for_node(node.name).empty?
+            # No jobs are allocated to this node.  So we're not waiting on any.
+            []
+          else
+            alloc_reg = FlightScheduler.app.allocations
+            jobs_as_they_complete(node).detect do |jobs|
+              alloc_reg.max_parallel_per_node(candidate, node, excluding_jobs: jobs) > 0
+            end
+          end
+        end
+    end
+
     def debug
-      "node=#{first.name} available_at=#{available_at} waiting on jobs=#{jobs.map(&:display_id)}"
+      "node=#{first.name} available_at=#{available_at} waiting on jobs_waited_on=#{jobs_waited_on.map(&:display_id)}"
+    end
+
+    private
+
+    # Returns an enumerator which yields arrays of jobs running on `node`.
+    #
+    # The first array yielded includes the first one job expected to complete.
+    # The second array yielded includes the first two jobs expected to complete.
+    # Etc..
+    #
+    # If a job does not have a known end time it is not included in any of the
+    # yielded array.
+    #
+    # If jobs have the same expected completion time, their relative order is
+    # undefined.
+    #
+    # These arrays allow us to determine the time at which we can guarantee
+    # that the node will be able to run `candidate`.  Or determine that there
+    # is no such time.
+    def jobs_as_they_complete(node)
+      jobs_ordered_by_end = FlightScheduler.app.allocations.for_node(node.name)
+        .map { |alloc| alloc.job }
+        .reject { |j| j.time_limit.nil? }
+        .sort_by { |j| j.time_limit }
+      Enumerator.new do |yielder|
+        jobs_ordered_by_end.length.times do |i|
+          yielder << jobs_ordered_by_end.slice(0, i + 1)
+        end
+      end
+    end
+  end
+
+  # Creates a reservation for the given `candidate` if one can be found.
+  #
+  # 1. Determine which nodes satisfy the job.
+  # 2. For each node, determine the earliest point at which the needed
+  #    resources on the node will become available.
+  # 3. Select the required number of nodes which are available first.
+  # 4. If necessary, add currently unallocated nodes to the selection.
+  class ReservationFinder
+    def initialize(candidate)
+      @candidate = candidate
+    end
+
+    def call
+      selection = select_nodes
+      return if selection.nil?
+
+      start_time = selection.last.available_at
+      end_time =
+        if @candidate.time_limit
+          start_time + @candidate.time_limit
+        else
+          nil
+        end
+      nodes = selection.map(&:node)
+      Reservation.new(@candidate, start_time, end_time, nodes)
+    end
+
+    private
+
+    def select_nodes
+      available_now, available_later = partition_nodes.slice(:unallocated, :later).values
+
+      selection = available_later
+        .sort_by(&:available_at)
+        .take(@candidate.min_nodes)
+
+      Async.logger.debug("Allocated nodes selected for reservation") {
+        selection.map(&:debug).join("\n")
+      }
+
+      if selection.empty?
+        # Not possible to create a reservation for this job.  It is requesting
+        # more resources than the partition currently has.
+        return nil
+      end
+
+      Async.logger.debug("Allocated nodes selected for reservation") {
+        selection.map(&:debug).join("\n")
+      }
+
+      if selection.length < @candidate.min_nodes
+        # We need to include some currently unused nodes in the reservation.
+        extra = available_now.take(@candidate.min_nodes - selection.length)
+        Async.logger.debug("Unallocated nodes added to reservation.") {
+          extra.map { |na| na.node.name }.join("\n")
+        }
+        selection.unshift(*extra)
+      end
+
+      if selection.length < @candidate.min_nodes
+        # We could not reserve sufficient resources.
+        return nil
+      end
+
+      selection
+    end
+
+    # Filter the partition's nodes to those that (1) have enough resources to
+    # run `candidate`; and (2) have a guaranteed time at which they can do so.
+    # Then partition those nodes into two categories:
+    #
+    # 1. Nodes that are not allocated to any job.
+    #
+    # 2. Nodes that are allocated to any job.
+    def partition_nodes
+      partitioned = {
+        unallocated: [],
+        later: [],
+      }
+      potential_nodes = @candidate.partition.nodes.select do |n|
+        n.satisfies_job?(@candidate)
+      end
+      Async.logger.debug("Potential nodes for reservation") { potential_nodes.map(&:name) }
+      node_availabilities = potential_nodes.map do |node|
+        NodeAvailability.new(node, @candidate)
+      end
+
+      node_availabilities.each do |availability|
+        if !availability.has_guarantee?
+          # There is no guarantee of when this node will be available.
+        elsif !availability.has_jobs?
+          partitioned[:unallocated] << availability
+        elsif availability.jobs_waited_on.empty?
+          partitioned[:later] << availability
+        else
+          partitioned[:later] << availability
+        end
+      end
+
+      partitioned
     end
   end
 
@@ -70,7 +231,7 @@ class BackfillingScheduler < BaseScheduler
       allocation = allocate_job(candidate, reservations: reservations)
       if allocation.nil?
         Async.logger.debug("Unable to allocate candidate #{candidate.display_id}. Attempting to backfill.")
-        reservation = create_reservation(candidate)
+        reservation = ReservationFinder.new(candidate).call
         if reservation.nil?
           Async.logger.debug("Unable to create reservation. Continuing normal allocation loop.")
         else
@@ -100,98 +261,6 @@ class BackfillingScheduler < BaseScheduler
       .select { |job| job.reason_pending == 'WaitingForScheduling' }
       .each { |job| job.reason_pending = 'Priority' }
     new_allocations
-  end
-
-  def create_reservation(candidate)
-    # 1. Determine which nodes satisfy the job.
-    # 2. For each node, determine the earliest point at which the needed
-    #    resources on the node will become available.
-    # 3. Select the required number of nodes which are available first.
-    # 4. If necessary, add currently unallocated nodes to the selection.
-
-    alloc_reg = FlightScheduler.app.allocations
-
-    potential_nodes = candidate.partition.nodes.select do |n|
-      n.satisfies_job?(candidate)
-    end
-
-    Async.logger.debug("Potential nodes for reservation") { potential_nodes.map(&:name) }
-
-    # For each potential node, grab the first set of jobs that need to
-    # complete in order for the candidate to run on it once.
-    availabilities = potential_nodes.reduce([]) do |accum, node|
-      jobs = jobs_in_completion_order(node).detect do |jobs|
-        alloc_reg.max_parallel_per_node(candidate, node, excluding_jobs: jobs) > 0
-      end
-      if jobs
-        accum << NodeAvailability.new(node, jobs)
-      end
-      accum
-    end
-
-    availabilities = availabilities
-      .sort_by(&:available_at)
-      .take(candidate.min_nodes)
-
-    if availabilities.empty?
-      # Not possible to create a reservation for this job.  It is requesting
-      # more resources than the partition currently has.
-      candidate.reason_pending = 'Resources'
-      return nil
-    end
-
-    Async.logger.debug("Allocated nodes selected for reservation") {
-      availabilities.map(&:debug).join("\n")
-    }
-
-    if availabilities.length < candidate.min_nodes
-      # We need to include some currently unused nodes in the reservation.
-
-      extra_nodes = potential_nodes
-        .select { |node| FlightScheduler.app.allocations.for_node(node.name).empty? }
-        .take(candidate.min_nodes - availabilities.length)
-
-      Async.logger.debug("Unallocated nodes added to reservation.") {
-        extra_nodes.map(&:name).join("\n")
-      }
-      availabilities.unshift(*extra_nodes.map { |node| NodeAvailability.new(node, []) })
-    end
-
-    if availabilities.length < candidate.min_nodes
-      # We could not reserve sufficient resources.
-      candidate.reason_pending = 'Resources'
-      return nil
-    end
-
-    start_time = availabilities.last.available_at
-    end_time =
-      if candidate.time_limit
-        start_time + candidate.time_limit
-      else
-        nil
-      end
-    nodes = availabilities.map(&:node)
-    Reservation.new(candidate, start_time, end_time, nodes)
-  end
-
-  # Yield an array of jobs in the order they are expected to complete.
-  #
-  # The first array yielded includes the first one job expected to complete.
-  # The second array yielded includes the first two jobs expected to complete.
-  # Etc..
-  #
-  # If jobs have the same expected completion time, their relative order is
-  # undefined.
-  def jobs_in_completion_order(node)
-    jobs_ordered_by_end = FlightScheduler.app.allocations.for_node(node.name)
-      .map { |alloc| alloc.job }
-      .reject { |j| j.time_limit.nil? }
-      .sort_by { |j| j.time_limit }
-    Enumerator.new do |yielder|
-      jobs_ordered_by_end.length.times do |i|
-        yielder << jobs_ordered_by_end.slice(0, i + 1)
-      end
-    end
   end
 
   def run_backfill_loop(reservations, candidates)

--- a/lib/flight_scheduler/schedulers/backfilling_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/backfilling_scheduler.rb
@@ -181,7 +181,7 @@ class BackfillingScheduler < BaseScheduler
     def availabilities_grouped_by_time_available
       @availabilities_grouped_by_time_available ||=
         begin
-          partitioned = {
+          grouped = {
             now: [],
           }
           potential_nodes = @candidate.partition.nodes.select do |n|
@@ -196,14 +196,14 @@ class BackfillingScheduler < BaseScheduler
             if !availability.has_guarantee?
               # There is no guarantee of when this node will be available.
             elsif availability.jobs_waited_on.empty?
-              partitioned[:now] << availability
+              grouped[:now] << availability
             else
-              partitioned[availability.available_at] ||= []
-              partitioned[availability.available_at] << availability
+              grouped[availability.available_at] ||= []
+              grouped[availability.available_at] << availability
             end
           end
 
-          partitioned
+          grouped
         end
     end
   end

--- a/lib/flight_scheduler/schedulers/base_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/base_scheduler.rb
@@ -150,20 +150,22 @@ class BaseScheduler
         end
 
         if job.job_type == 'ARRAY_JOB'
-          previous_task = nil
-          loop do
-            next_task = job.task_generator.next_task
-            if next_task == previous_task
-              # We failed to schedule the ARRAY_TASK.  Move onto the next
-              # ARRAY_JOB or JOB.
-              break
-            elsif next_task.nil?
-              # We've exhausted the ARRAY_JOB.  Move onto the next ARRAY_JOB
-              # or JOB.
-              break
-            else
-              previous_task = next_task
-              yielder << next_task
+          catch :done_with_array_job do
+            previous_task = nil
+            loop do
+              next_task = job.task_generator.next_task
+              if next_task == previous_task
+                # We failed to schedule the ARRAY_TASK.  Move onto the next
+                # ARRAY_JOB or JOB.
+                throw :done_with_array_job
+              elsif next_task.nil?
+                # We've exhausted the ARRAY_JOB.  Move onto the next ARRAY_JOB
+                # or JOB.
+                throw :done_with_array_job
+              else
+                previous_task = next_task
+                yielder << next_task
+              end
             end
           end
         else

--- a/spec/schedulers/backfilling_scheduler/bias_spec.rb
+++ b/spec/schedulers/backfilling_scheduler/bias_spec.rb
@@ -1,0 +1,150 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+require 'spec_helper'
+require_relative '../../../lib/flight_scheduler/schedulers/backfilling_scheduler'
+require_relative '../shared_scheduler_spec'
+
+RSpec.describe BackfillingScheduler, type: :scheduler do
+  describe 'backfilling bias' do
+    include ActiveSupport::Testing::TimeHelpers
+
+    before(:each) {
+      # To aid test readability, the backfilling tests are written in terms
+      # of "rounds" rather than time.
+      #
+      # This introduces an issue where jobs are not being backfilled because
+      # they end a fraction of a second after a reservation is due to start.
+      # This issue is fixed by fixing the time.
+      travel_to Time.now
+    }
+
+    let(:partition) {
+      build(:partition, name: 'all', nodes: nodes, max_time_limit_spec: 10, default_time_limit_spec: 5)
+    }
+    let(:partitions) { [ partition ] }
+    let(:scheduler) { subject }
+    let(:allocations) { FlightScheduler.app.allocations }
+    let(:job_registry) { FlightScheduler.app.job_registry }
+    subject { described_class.new }
+
+    before(:each) { allocations.send(:clear); job_registry.send(:clear) }
+
+    def build_job(**kwargs)
+      build(:job, partition: partition, **kwargs)
+    end
+
+    context 'reservations are biased towards allocated nodes' do
+      before(:each) {
+        test_data.each do |datum|
+          job_registry.add(datum.job)
+        end
+      }
+
+      context 'when the nodes are fully allocated' do
+        let(:nodes) {
+          [
+            build(:node, name: 'node01', cpus: 1),
+            build(:node, name: 'node02', cpus: 1),
+            build(:node, name: 'node03', cpus: 1),
+            build(:node, name: 'node04', cpus: 1),
+          ].tap do |a|
+            a.each do |node|
+              allow(node).to receive(:connected?).and_return true
+            end
+          end
+        }
+
+        # In round 1 a reservation for job 3 will be created.  It will be
+        # created to run once job 2 has completed.  This allows job 4 to be
+        # backfilled in round 1.
+        let(:test_data) {
+          TestData = NonArrayTestData
+          [
+            TestData.new(
+              job: build_job(id: 1, min_nodes: 1, time_limit_spec: 1),
+              allocated_in_round: 1,
+            ),
+            TestData.new(
+              job: build_job(id: 2, min_nodes: 1, time_limit_spec: 2),
+              allocated_in_round: 1,
+            ),
+            TestData.new(
+              job: build_job(id: 3, min_nodes: 3, time_limit_spec: 1),
+              allocated_in_round: 3,
+            ),
+            TestData.new(
+              job: build_job(id: 4, min_nodes: 2, time_limit_spec: 2),
+              allocated_in_round: 1,
+            ),
+          ]
+        }
+
+        include_examples 'allocation specs for non-array jobs'
+      end
+
+      context 'when the nodes are not fully allocated' do
+        let(:nodes) {
+          [
+            build(:node, name: 'node01', cpus: 3),
+          ].tap do |a|
+            a.each do |node|
+              allow(node).to receive(:connected?).and_return true
+            end
+          end
+        }
+
+        # In round 1 a reservation for job 3 will be created.  It will be
+        # created to run once job 2 has completed.  This allows job 4 to be
+        # backfilled in round 1.
+        let(:test_data) {
+          TestData = NonArrayTestData
+          [
+            TestData.new(
+              job: build_job(id: 1, min_nodes: 1, cpus_per_node: 1, time_limit_spec: 1),
+              allocated_in_round: 1,
+            ),
+            TestData.new(
+              job: build_job(id: 2, min_nodes: 1, cpus_per_node: 1, time_limit_spec: 2),
+              allocated_in_round: 1,
+            ),
+            TestData.new(
+              job: build_job(id: 3, min_nodes: 1, cpus_per_node: 2, time_limit_spec: 1),
+              allocated_in_round: 2,
+            ),
+            TestData.new(
+              job: build_job(id: 4, min_nodes: 1, cpus_per_node: 1, time_limit_spec: 2),
+              allocated_in_round: 3,
+            ),
+          ]
+        }
+
+        include_examples 'allocation specs for non-array jobs'
+      end
+    end
+  end
+end

--- a/spec/schedulers/backfilling_scheduler/non_homogenous_nodes_spec.rb
+++ b/spec/schedulers/backfilling_scheduler/non_homogenous_nodes_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe BackfillingScheduler, type: :scheduler do
       let(:nodes) {
         [
           build(:node, name: 'node01', cpus: 1),
-          build(:node, name: 'node02', cpus: 1),
-          build(:node, name: 'node03', cpus: 1),
-          build(:node, name: 'node04', cpus: 1),
+          build(:node, name: 'node02', cpus: 2),
+          build(:node, name: 'node03', cpus: 3),
+          build(:node, name: 'node04', cpus: 4),
         ].tap do |a|
           a.each do |node|
             allow(node).to receive(:connected?).and_return true
@@ -67,24 +67,26 @@ RSpec.describe BackfillingScheduler, type: :scheduler do
           TestData = ArrayTestData
           [
             TestData.new(
-              job: build_job(id: 1, array: '1-2', min_nodes: 2),
+              job: build_job(id: 1, array: '1-2', min_nodes: 1, cpus_per_node: 4),
               run_time: 2,
-              allocations_in_round: { 1 => 2 },
+              allocations_in_round: { 1 => 1, 3 => 1 },
             ),
             TestData.new(
-              job: build_job(id: 2, array: '1-2', min_nodes: 2),
+              job: build_job(id: 2, array: '1-2', min_nodes: 2, cpus_per_node: 2),
               run_time: 3,
-              allocations_in_round: { 3 => 2 },
+              allocations_in_round: { 1 => 1, 4 => 1 },
             ),
             TestData.new(
-              job: build_job(id: 3, array: '1-4', min_nodes: 1),
+              job: build_job(id: 3, array: '1-4', min_nodes: 1, cpus_per_node: 3),
               run_time: 1,
-              allocations_in_round: { 6 => 4 },
+              allocations_in_round: { 5 => 1, 6 => 1, 7 => 2},
             ),
             TestData.new(
-              job: build_job(id: 4, array: '1-20', min_nodes: 1),
+              job: build_job(id: 4, array: '1-20', min_nodes: 1, cpus_per_node: 1),
               run_time: 1,
-              allocations_in_round: { 7 => 4, 8 => 4, 9 => 4, 10 => 4, 11 => 4},
+              allocations_in_round: {
+                1 => 2, 2 => 2, 3 => 2, 4 => 2, 5 => 3, 6 => 3, 7 => 4, 8 => 2,
+              },
             ),
           ]
         }

--- a/spec/schedulers/backfilling_scheduler/non_homogenous_nodes_spec.rb
+++ b/spec/schedulers/backfilling_scheduler/non_homogenous_nodes_spec.rb
@@ -72,6 +72,44 @@ RSpec.describe BackfillingScheduler, type: :scheduler do
         build(:job, partition: partition, **kwargs)
       end
 
+      context 'backfilling with non-array jobs' do
+        context 'backfilling respects reservations' do
+          include_examples 'allocation specs for non-array jobs'
+
+          let(:test_data) {
+            TestData = NonArrayTestData
+            [
+              TestData.new(
+                job: build_job(id: 1, min_nodes: 4, cpus_per_node: 1, time_limit_spec: 1),
+                allocated_in_round: 1,
+              ),
+              TestData.new(
+                job: build_job(id: 2, min_nodes: 3, cpus_per_node: 2, time_limit_spec: 2),
+                allocated_in_round: 2,
+              ),
+              TestData.new(
+                job: build_job(id: 3, min_nodes: 2, cpus_per_node: 2, time_limit_spec: 2),
+                allocated_in_round: 4,
+              ),
+              TestData.new(
+                job: build_job(id: 4, min_nodes: 2, cpus_per_node: 2, time_limit_spec: 1),
+                allocated_in_round: 1,
+              ),
+              TestData.new(
+                job: build_job(id: 5, min_nodes: 1, cpus_per_node: 1, time_limit_spec: 1),
+                allocated_in_round: 1,
+              ),
+            ]
+          }
+
+          before(:each) {
+            test_data.each do |datum|
+              job_registry.add(datum.job)
+            end
+          }
+        end
+      end
+
       context 'backfilling with array jobs' do
         include_examples 'allocation specs for array jobs'
 

--- a/spec/schedulers/backfilling_scheduler/non_homogenous_nodes_spec.rb
+++ b/spec/schedulers/backfilling_scheduler/non_homogenous_nodes_spec.rb
@@ -1,0 +1,100 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+require 'spec_helper'
+require_relative '../../../lib/flight_scheduler/schedulers/backfilling_scheduler'
+require_relative '../shared_scheduler_spec'
+
+RSpec.describe BackfillingScheduler, type: :scheduler do
+  describe '#allocate_jobs' do
+    context 'non-homogenous nodes' do
+      let(:partition) {
+        build(:partition, name: 'all', nodes: nodes, max_time_limit_spec: 10, default_time_limit_spec: 5)
+      }
+      let(:partitions) { [ partition ] }
+      let(:nodes) {
+        [
+          build(:node, name: 'node01', cpus: 1),
+          build(:node, name: 'node02', cpus: 1),
+          build(:node, name: 'node03', cpus: 1),
+          build(:node, name: 'node04', cpus: 1),
+        ].tap do |a|
+          a.each do |node|
+            allow(node).to receive(:connected?).and_return true
+          end
+        end
+      }
+
+      let(:scheduler) { subject }
+      let(:allocations) { FlightScheduler.app.allocations }
+      let(:job_registry) { FlightScheduler.app.job_registry }
+      subject { described_class.new }
+
+      before(:each) { allocations.send(:clear); job_registry.send(:clear) }
+
+      def build_job(**kwargs)
+        build(:job, partition: partition, **kwargs)
+      end
+
+      context 'backfilling with array jobs' do
+        include_examples 'allocation specs for array jobs'
+
+        let(:test_data) {
+          TestData = ArrayTestData
+          [
+            TestData.new(
+              job: build_job(id: 1, array: '1-2', min_nodes: 2),
+              run_time: 2,
+              allocations_in_round: { 1 => 2 },
+            ),
+            TestData.new(
+              job: build_job(id: 2, array: '1-2', min_nodes: 2),
+              run_time: 3,
+              allocations_in_round: { 3 => 2 },
+            ),
+            TestData.new(
+              job: build_job(id: 3, array: '1-4', min_nodes: 1),
+              run_time: 1,
+              allocations_in_round: { 6 => 4 },
+            ),
+            TestData.new(
+              job: build_job(id: 4, array: '1-20', min_nodes: 1),
+              run_time: 1,
+              allocations_in_round: { 7 => 4, 8 => 4, 9 => 4, 10 => 4, 11 => 4},
+            ),
+          ]
+        }
+
+        before(:each) {
+          test_data.each do |datum|
+            job_registry.add(datum.job)
+          end
+        }
+      end
+    end
+  end
+end

--- a/spec/schedulers/backfilling_scheduler_spec.rb
+++ b/spec/schedulers/backfilling_scheduler_spec.rb
@@ -408,9 +408,15 @@ RSpec.describe BackfillingScheduler, type: :scheduler do
           }
 
           # In round 1 three nodes are allocated.  Two of them are allocated
-          # to a job without a timelimit.  This means that no reservation for
-          # job 3 is possible in round 1.  Because there is no reservation for
-          # job 3, job 4 can be allocated.
+          # to Job 2, a job without a timelimit.
+          #
+          # These nodes are therefore not available to be used as part of a
+          # reservation, preventing a reservation for Job 3 in round 1.
+          #
+          # Job 4 cannot be allocated (or backfilled) in round 1 as the
+          # reservation for Job 3 could not be created.  If we allowed, Job 4
+          # to be backfilled, it could potentially delay the highest priority
+          # job, Job 3.
           let(:test_data) {
             TestData = NonArrayTestData
             [
@@ -428,7 +434,7 @@ RSpec.describe BackfillingScheduler, type: :scheduler do
               ),
               TestData.new(
                 job: build_job(id: 4, min_nodes: 1, time_limit_spec: 2),
-                allocated_in_round: 1,
+                allocated_in_round: 2,
               ),
             ]
           }

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -61,13 +61,11 @@ RSpec.describe FifoScheduler, type: :scheduler do
   #       consider refactoring
   before(:each) { allocations.send(:clear); job_registry.send(:clear) }
 
-  include_examples 'basic scheduler specs'
-  include_examples '(basic) #queue specs'
-  include_examples '(basic) job completion or cancellation specs'
+  include_examples 'common scheduler specs'
 
   describe '#allocate_jobs' do
-    def make_job(job_id, min_nodes, **kwargs)
-      build(:job, id: job_id, min_nodes: min_nodes, partition: partition, **kwargs)
+    def build_job(**kwargs)
+      build(:job, partition: partition, **kwargs)
     end
 
     def add_allocation(job, nodes)
@@ -95,7 +93,7 @@ RSpec.describe FifoScheduler, type: :scheduler do
         ]
 
         min_node_requirements.each_with_index.map do |min_nodes, job_id|
-          make_job(job_id, min_nodes)
+          build_job(id: job_id, min_nodes: min_nodes)
         end
       end
 
@@ -140,126 +138,95 @@ RSpec.describe FifoScheduler, type: :scheduler do
 
     context 'multiple calls' do
       context 'for non-array jobs' do
+        include_examples 'allocation specs for non-array jobs'
+
         let(:test_data) {
+          TestData = NonArrayTestData
           [
-            { job_id: 1, min_nodes: 1, run_time: 2, allocated_in_round: 1 },
-            { job_id: 2, min_nodes: 1, run_time: 1, allocated_in_round: 1 },
-            { job_id: 3, min_nodes: 3, run_time: 3, allocated_in_round: 2 },
-            { job_id: 4, min_nodes: 2, run_time: 3, allocated_in_round: 5 },
-            { job_id: 5, min_nodes: 1, run_time: 2, allocated_in_round: 5 },
-            { job_id: 6, min_nodes: 2, run_time: 1, allocated_in_round: 7 },
+            TestData.new(
+              job: build_job(id: 1, min_nodes: 1),
+              run_time: 2,
+              allocated_in_round: 1,
+            ),
+            TestData.new(
+              job: build_job(id: 2, min_nodes: 1),
+              run_time: 1,
+              allocated_in_round: 1,
+            ),
+            TestData.new(
+              job: build_job(id: 3, min_nodes: 3),
+              run_time: 3,
+              allocated_in_round: 2,
+            ),
+            TestData.new(
+              job: build_job(id: 4, min_nodes: 2),
+              run_time: 3,
+              allocated_in_round: 5,
+            ),
+            TestData.new(
+              job: build_job(id: 5, min_nodes: 1),
+              run_time: 2,
+              allocated_in_round: 5,
+            ),
+            TestData.new(
+              job: build_job(id: 6, min_nodes: 2),
+              run_time: 1,
+              allocated_in_round: 7,
+            ),
           ]
         }
 
         before(:each) {
           test_data.each do |datum|
-            job = make_job(datum[:job_id], datum[:min_nodes])
-            job_registry.add(job)
+            job_registry.add(datum.job)
           end
         }
-
-        it 'allocates the correct nodes to the correct jobs in the correct order' do
-          num_rounds = test_data.map { |d| d[:allocated_in_round] }.max
-          num_rounds.times.each do |round|
-            round += 1
-
-            # Progress any completed jobs.
-            allocations.each do |allocation|
-              datum = test_data.detect { |d| d[:job_id] == allocation.job.id }
-              datum[:run_time] -= 1
-              if datum[:run_time] == 0
-                allocation.nodes.dup.each do |node|
-                  allocations.deallocate_node_from_job(allocation.job.id, node.name)
-                end
-                allocation.job.state = 'COMPLETED'
-              end
-            end
-
-            expected_allocations = test_data
-              .select { |d| d[:allocated_in_round] == round }
-
-            expect { scheduler.allocate_jobs(partitions: partitions) }.to \
-              change { allocations.size }.by(expected_allocations.length)
-            expected_allocations.each do |datum|
-              allocation = allocations.for_job(datum[:job_id])
-              expect(allocation).not_to be_nil
-            end
-          end
-        end
       end
 
       context 'for array jobs' do
-        class TestDataFIFO < Struct.new(:job_id, :array, :min_nodes, :run_time, :allocations_in_round)
-          def initialize(*args)
-            super
-            @run_time_for_tasks = {}
-          end
-
-          def reduce_remaining_runtime(allocation)
-            @run_time_for_tasks[allocation] ||= run_time
-            @run_time_for_tasks[allocation] -= 1
-          end
-
-          def completed_tasks
-            @run_time_for_tasks.select { |key, value| value == 0 }.keys
-          end
-        end
+        include_examples 'allocation specs for array jobs'
 
         let(:test_data) {
+        TestData = ArrayTestData
           [
-            #           Job id, array, min_nodes, run_time, allocations_in_round
-            TestDataFIFO.new(1,     '1-2', 1,         2,        { 1 => 2 }),
-            TestDataFIFO.new(2,     '1-2', 3,         3,        { 3 => 1, 6 => 1 }),
-            TestDataFIFO.new(3,     '1-2', 2,         3,        { 9 => 2 }),
-            TestDataFIFO.new(4,     '1-5', 1,         1,        { 12 => 4, 13 => 1 }),
-            TestDataFIFO.new(5,     '1-2', 3,         1,        { 13 => 1, 14 => 1 }),
-            TestDataFIFO.new(6,     '1-2', 2,         1,        { 15 => 2 }),
+            TestData.new(
+              job: build_job(id: 1, array: '1-2', min_nodes: 1),
+              run_time: 2,
+              allocations_in_round: { 1 => 2 },
+            ),
+            TestData.new(
+              job: build_job(id: 2, array: '1-2', min_nodes: 3),
+              run_time: 3,
+              allocations_in_round: { 3 => 1, 6 => 1 },
+            ),
+            TestData.new(
+              job: build_job(id: 3, array: '1-2', min_nodes: 2),
+              run_time: 3,
+              allocations_in_round: { 9 => 2 },
+            ),
+            TestData.new(
+              job: build_job(id: 4, array: '1-5', min_nodes: 1),
+              run_time: 1,
+              allocations_in_round: { 12 => 4, 13 => 1 },
+            ),
+            TestData.new(
+              job: build_job(id: 5, array: '1-2', min_nodes: 3),
+              run_time: 1,
+              allocations_in_round: { 13 => 1, 14 => 1 },
+            ),
+            TestData.new(
+              job: build_job(id: 6, array: '1-2', min_nodes: 2),
+              run_time: 1,
+              allocations_in_round: { 15 => 2 },
+            ),
           ]
         }
 
         before(:each) {
           test_data.each do |datum|
-            job = make_job(datum.job_id, datum.min_nodes, array: datum.array)
-            job_registry.add(job)
+            job_registry.add(datum.job)
           end
         }
-
-        it 'allocates the correct nodes to the correct jobs in the correct order' do
-          num_rounds = test_data.map { |d| d.allocations_in_round.keys }.flatten.max
-          num_rounds.times.each do |round|
-            round += 1
-
-            # Progress any completed jobs.
-            allocations.each do |allocation|
-              datum = test_data.detect { |d| d.job_id == allocation.job.array_job.id }
-              datum.reduce_remaining_runtime(allocation)
-              datum.completed_tasks.each do |allocation|
-                allocation.nodes.dup.each do |node|
-                  allocations.deallocate_node_from_job(allocation.job.id, node.name)
-                end
-                allocation.job.state = 'COMPLETED'
-              end
-            end
-
-            array_jobs_with_allocations_this_round = test_data
-              .select { |d| d.allocations_in_round[round] }
-            total_allocations_this_round = array_jobs_with_allocations_this_round
-              .map { |d| d.allocations_in_round[round] }
-              .sum
-
-            new_allocations = scheduler.allocate_jobs(partitions: partitions)
-            expect(new_allocations.length).to eq total_allocations_this_round
-
-            allocations_by_array_job = new_allocations.group_by do |allocation|
-              allocation.job.array_job.id
-            end
-
-            array_jobs_with_allocations_this_round.each do |datum|
-              allocations = allocations_by_array_job[datum.job_id]
-              expect(allocations.length).to eq datum.allocations_in_round[round]
-            end
-          end
-        end
       end
     end
   end

--- a/spec/schedulers/fifo_scheduler_spec.rb
+++ b/spec/schedulers/fifo_scheduler_spec.rb
@@ -144,33 +144,27 @@ RSpec.describe FifoScheduler, type: :scheduler do
           TestData = NonArrayTestData
           [
             TestData.new(
-              job: build_job(id: 1, min_nodes: 1),
-              run_time: 2,
+              job: build_job(id: 1, min_nodes: 1, time_limit_spec: 2),
               allocated_in_round: 1,
             ),
             TestData.new(
-              job: build_job(id: 2, min_nodes: 1),
-              run_time: 1,
+              job: build_job(id: 2, min_nodes: 1, time_limit_spec: 1),
               allocated_in_round: 1,
             ),
             TestData.new(
-              job: build_job(id: 3, min_nodes: 3),
-              run_time: 3,
+              job: build_job(id: 3, min_nodes: 3, time_limit_spec: 3),
               allocated_in_round: 2,
             ),
             TestData.new(
-              job: build_job(id: 4, min_nodes: 2),
-              run_time: 3,
+              job: build_job(id: 4, min_nodes: 2, time_limit_spec: 3),
               allocated_in_round: 5,
             ),
             TestData.new(
-              job: build_job(id: 5, min_nodes: 1),
-              run_time: 2,
+              job: build_job(id: 5, min_nodes: 1, time_limit_spec: 2),
               allocated_in_round: 5,
             ),
             TestData.new(
-              job: build_job(id: 6, min_nodes: 2),
-              run_time: 1,
+              job: build_job(id: 6, min_nodes: 2, time_limit_spec: 1),
               allocated_in_round: 7,
             ),
           ]
@@ -190,33 +184,27 @@ RSpec.describe FifoScheduler, type: :scheduler do
         TestData = ArrayTestData
           [
             TestData.new(
-              job: build_job(id: 1, array: '1-2', min_nodes: 1),
-              run_time: 2,
+              job: build_job(id: 1, array: '1-2', min_nodes: 1, time_limit_spec: 2),
               allocations_in_round: { 1 => 2 },
             ),
             TestData.new(
-              job: build_job(id: 2, array: '1-2', min_nodes: 3),
-              run_time: 3,
+              job: build_job(id: 2, array: '1-2', min_nodes: 3, time_limit_spec: 3),
               allocations_in_round: { 3 => 1, 6 => 1 },
             ),
             TestData.new(
-              job: build_job(id: 3, array: '1-2', min_nodes: 2),
-              run_time: 3,
+              job: build_job(id: 3, array: '1-2', min_nodes: 2, time_limit_spec: 3),
               allocations_in_round: { 9 => 2 },
             ),
             TestData.new(
-              job: build_job(id: 4, array: '1-5', min_nodes: 1),
-              run_time: 1,
+              job: build_job(id: 4, array: '1-5', min_nodes: 1, time_limit_spec: 1),
               allocations_in_round: { 12 => 4, 13 => 1 },
             ),
             TestData.new(
-              job: build_job(id: 5, array: '1-2', min_nodes: 3),
-              run_time: 1,
+              job: build_job(id: 5, array: '1-2', min_nodes: 3, time_limit_spec: 1),
               allocations_in_round: { 13 => 1, 14 => 1 },
             ),
             TestData.new(
-              job: build_job(id: 6, array: '1-2', min_nodes: 2),
-              run_time: 1,
+              job: build_job(id: 6, array: '1-2', min_nodes: 2, time_limit_spec: 1),
               allocations_in_round: { 15 => 2 },
             ),
           ]

--- a/spec/schedulers/shared_scheduler_spec.rb
+++ b/spec/schedulers/shared_scheduler_spec.rb
@@ -383,7 +383,7 @@ RSpec.shared_examples 'allocation specs for non-array jobs' do
     end
   end
 
-  let(:num_rounds) { test_data.map { |d| d.allocated_in_round }.max }
+  let(:num_rounds) { test_data.map { |d| d.allocated_in_round }.compact.max }
 
   def progress_completed_jobs
     allocations.each do |allocation|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,7 @@ Bundler.require(:default, :test)
 
 require 'fakefs/safe'
 require 'rack/test'
+require 'active_support/testing/time_helpers'
 
 require_relative '../app.rb'
 require_relative '../app/websocket_app'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,3 +147,12 @@ RSpec.configure do |config|
     end
   end
 end
+
+# Similar to +Struct+ but initialised using keyword arguments.
+#
+# From https://stackoverflow.com/a/38811145/2620402.
+class KeywordStruct < Struct
+  def initialize(**kwargs)
+    super(*members.map{|k| kwargs.fetch(k) })
+  end
+end


### PR DESCRIPTION
This PR is the second pass at a backfilling scheduler.  It is a significant rewrite of the firstaattempt with the following changes in behaviour.

1. Backfilling can only happen if a job has a run time limit, either defined by the user or using the default from the partition.

2. Backfilling works correctly for non-homogenous nodes on a partition.


## Algorithm

The algorithm used is based on the algorithm described in http://docs.adaptivecomputing.com/maui/8.2backfill.php. With the following changes:

1. Backfill windows are implicitly modelled.
2. The fit algorithm is a "quietest node" algorithm.

I'll describe the algorithm here in brief(ish).

When the backfilling scheduler schedules jobs for a partition, it iterates over the jobs and attepts to resources to each job.  If successful it moves onto allocate the next job.  This is so far idential to the behaviour of the FIFO scheduler.  If the scheduler cannot allocate resources to a job it attempts to create a reservation for that job.

To create a reservation, the scheduler looks at all nodes with sufficient resources to run the candidate job.  It then looks at the jobs running on the node and orders them by their guaranteed end time.  The scheduler then determines at what point in time the node will have sufficient resources available to run the candiate job assuming its current jobs stop in the order previously determined.  This gives us the time at which we can guarantee that the node will be available to run the candidate job.

Once we have such an end time for all nodes capable of running the candidate job we can calculate the earliest point at which we can guarantee there will be sufficient resources to run the candidate job.

Using those "availability times", we create a reservation.  Selecting the nodes that will allow the candidate job to run at the earliest time possible.

Where there is a choice of two nodes to add to the reservation, either of which would not change the guaranteed start time.  We prefer the node which is not currently able to run the job over one that can.  This is an attempt to allow as much backfilling as possible.

Once the reservation is created, we continue examining the remaining jobs and see if any can be allocated resources without using the resources that are part of the reservation.

If a backfill candidate cannot be allocated, we continue considering the remaining jobs, until we have either considered all jobs or we have reached the limit of the number of jobs to consider whilst allocating resources.


## Allocation vs Reservation

Reservations are similar to allocations, but they differ in a couple of respects.

 1. An allocation is fixed.  Once it has been added to the allocation registry we are committed to it.

 2. A reservation is ephemeral.  Once it is created, the only part of it we are committed to is that the start time will not be delayed.  The start time could be brought forward, and the selected nodes could change entirely.


# Limitations

If a node belongs to multiple partitions, the behaviour of reservations for that node is not defined.  I don't currently, know what the desired behaviour would be; does one partition respect the reservations made by another partition?  Do reservations (or partitions) have a priority order, such that higher priority partitions can overrule lower reservations from lower priority partitions?  A reservation is to be made on the highest priority job.  Is priority global or is it per partition?  How does this interact with partition priorities if such things exist?  These are questions for a later time.



# Future work

## Better fit algorithm

Currently, when selecting which resource can be allocated to a job, we chose the node that can run the job the most number of times, i.e., a "quietest fit" algorithm.  This fit algorithm is used both for the initial allocation of jobs and for backfilling jobs.

We use a slightly different algorithm for determining which nodes should be added to a reservation.  That algorithm is detailed above.

We should add alternative fit algorithms, such as a "first fit" and a "best fit" algorithm and allow them to be configurable.  These algorithms should be used for the initial allocation, backfilling and reservation creation.

Implementing this is likely to require the "allocation windows" mentioned in the linked paper.

## Create a configurable number of reservations

Currently, a single reservation for the highest priority job is created.  We should allow creating reservations for the highest N priority jobs.
