### PR TITLE
Replace static nodes with a list matcher

### DIFF
--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -103,6 +103,7 @@ class Partition
     @default_time_limit_spec = default_time_limit_spec
     @node_matchers_spec = node_matchers_spec
     @types_spec = types_spec || {}
+    # TODO: Remove me complete!
     @static_node_names = static_node_names || []
     @excess_script    = excess_script
     @insufficient_script  = insufficient_script

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -88,7 +88,6 @@ class Partition
   def initialize(
     name:,
     default: false,
-    static_node_names: nil,
     default_time_limit_spec: nil,
     max_time_limit_spec: nil,
     node_matchers_spec: nil,
@@ -103,8 +102,6 @@ class Partition
     @default_time_limit_spec = default_time_limit_spec
     @node_matchers_spec = node_matchers_spec
     @types_spec = types_spec || {}
-    # TODO: Remove me complete!
-    @static_node_names = static_node_names || []
     @excess_script    = excess_script
     @insufficient_script  = insufficient_script
     @status_script  = status_script
@@ -116,7 +113,6 @@ class Partition
   end
 
   def node_match?(node)
-    return true if @static_node_names.include? node.name
     return false if matchers.empty?
     matchers.all? { |m| m.match?(node) }
   end

--- a/app/models/partition/builder.rb
+++ b/app/models/partition/builder.rb
@@ -34,7 +34,6 @@ class Partition
       "properties" => {
         "name" => { "type" => 'string' },
         "default" => { "type" => 'boolean' },
-        "nodes" => { "type" => "array", "items" => { "type" => "string" } },
         "max_time_limit" => { "type" => ['string', 'integer'] },
         "default_time_limit" => { "type" => ['string', 'integer'] },
         "node_matchers" => FlightScheduler::NodeMatcher::SCHEMA,
@@ -101,7 +100,7 @@ class Partition
         spec_attrs = spec.slice(*SPEC_KEYS).transform_keys { |k| :"#{k}_spec" }
         other_attrs = spec.slice(*OTHER_KEYS).transform_keys(&:to_sym)
         script_attrs = spec.fetch('event_scripts', {}).transform_keys { |k| "#{k}_script".to_sym }
-        Partition.new(**other_attrs, **spec_attrs, **script_attrs, static_node_names: spec['nodes'])
+        Partition.new(**other_attrs, **spec_attrs, **script_attrs)
       end
     end
 

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -154,6 +154,9 @@ partitions:
 #                                 partition, uses time notation
 #   node_matchers: [OBJECT] - The dynamic nodes specification
 #     name: [OBJECT]        - Matches based on the node name
+#       list: [ARRAY]       - A discrete list the node must appear in
+#         - <STRING>        - At least one node given by name
+#         ...
 #       regex: [STRING]     - Pattern matches based on ruby regex notation.
 #                             This match will implicitly wild card the begining
 #                             and end. To preform an exact match, it must be
@@ -166,6 +169,9 @@ partitions:
 #       lte:  [INTEGER]     - Must be less than or equal to the given number
 #       gt:   [INTEGER]     - Must be greater than the given number
 #       gte:  [INTEGER]     - Must be greater than or equal to the given number
+#       list: [ARRAY]       - A discrete list of allowed resources amounts
+#         - <INTEGER>       - At least one resource amount as an integer
+#         ...
 #     gpus:   [OBJECT]      - Matches based on the number of cpus
 #       ...                 - Same as cpus section
 #     memory: [OBJECT]      - Matches based on the available memory

--- a/etc/flight-scheduler-controller.yaml
+++ b/etc/flight-scheduler-controller.yaml
@@ -148,9 +148,6 @@ partitions:
 # - name:    <STRING>       - The name of the partition, must be unique
 #   default: [BOOLEAN]      - Flags the default partition,
 #                             must be true for exactly one partition
-#   nodes: [ARRAY]          - A list of statically define nodes
-#     - <STRING>            - The name of the node
-#     ...
 #   max_time_limit: [TIME]  - The maximum a job can run on the partition,
 #                             uses time notation
 #   default_time_limit: [TIME]  - The default time a job can run on the

--- a/lib/flight_scheduler/node_matcher.rb
+++ b/lib/flight_scheduler/node_matcher.rb
@@ -45,7 +45,11 @@ module FlightScheduler
             'lt' => { "type" => 'integer' },
             'lte' => { "type" => 'integer' },
             'gt' => { "type" => 'integer' },
-            'gte' => { "type" => 'integer' }
+            'gte' => { "type" => 'integer' },
+            'list' => {
+              "type" => 'array',
+              'items' => { 'type' => ['integer', 'string'] }
+            }
           }
         }
       }
@@ -99,6 +103,11 @@ module FlightScheduler
     def gte(int)
       return false unless int.is_a? Integer
       int >= specs['gte']
+    end
+
+    def list(value)
+      @list_hash ||= Hash.new(false).merge!(specs['list'].map { |k| [k, true] }.to_h)
+      @list_hash[value]
     end
   end
 end

--- a/lib/flight_scheduler/node_matcher.rb
+++ b/lib/flight_scheduler/node_matcher.rb
@@ -48,6 +48,7 @@ module FlightScheduler
             'gte' => { "type" => 'integer' },
             'list' => {
               "type" => 'array',
+              "minItems" => 1,
               'items' => { 'type' => ['integer', 'string'] }
             }
           }

--- a/spec/models/partition/builder_spec.rb
+++ b/spec/models/partition/builder_spec.rb
@@ -90,11 +90,6 @@ RSpec.describe Partition::Builder do
     end
   end
 
-  specify 'nodes can be an array of strings' do
-    specs = [generate_spec(nodes: ['foo', 'bar'])]
-    expect(described_class.new(specs)).to be_valid
-  end
-
   specify 'nodes can not be a string' do
     specs = [generate_spec(nodes: 'foobar')]
     expect(described_class.new(specs)).not_to be_valid

--- a/spec/node_matcher_spec.rb
+++ b/spec/node_matcher_spec.rb
@@ -153,4 +153,24 @@ RSpec.describe FlightScheduler::NodeMatcher do
       expect(build(:node_matcher, regex: '\Anode\d+\Z').regex('node01')).to be true
     end
   end
+
+  describe '#list' do
+    let(:values) { [1, 'foo'] }
+
+    it 'can match strings' do
+      expect(build(:node_matcher, list: values).list('foo')).to be true
+    end
+
+    it 'can reject strings' do
+      expect(build(:node_matcher, list: values).list('bar')).to be false
+    end
+
+    it 'can match integers' do
+      expect(build(:node_matcher, list: values).list(1)).to be true
+    end
+
+    it 'can reject integers' do
+      expect(build(:node_matcher, list: values).list(2)).to be false
+    end
+  end
 end

--- a/spec/node_matcher_spec.rb
+++ b/spec/node_matcher_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe FlightScheduler::NodeMatcher do
     let(:value) { 10 }
 
     it 'returns false for non-integers' do
-      expect(build(:node_matcher, lt: 1).lt('foo')).to be false
+      expect(build(:node_matcher, lt: value).lt('foo')).to be false
     end
 
     it 'is true for less than' do
@@ -75,7 +75,7 @@ RSpec.describe FlightScheduler::NodeMatcher do
     let(:value) { 10 }
 
     it 'returns false for non-integers' do
-      expect(build(:node_matcher, lte: 1).lte('foo')).to be false
+      expect(build(:node_matcher, lte: value).lte('foo')).to be false
     end
 
     it 'is true for less than' do
@@ -95,7 +95,7 @@ RSpec.describe FlightScheduler::NodeMatcher do
     let(:value) { 10 }
 
     it 'returns false for non-integers' do
-      expect(build(:node_matcher, gt: 1).gt('foo')).to be false
+      expect(build(:node_matcher, gt: value).gt('foo')).to be false
     end
 
     it 'is false for less than' do
@@ -115,7 +115,7 @@ RSpec.describe FlightScheduler::NodeMatcher do
     let(:value) { 10 }
 
     it 'returns false for non-integers' do
-      expect(build(:node_matcher, gte: 1).gte('foo')).to be false
+      expect(build(:node_matcher, gte: value).gte('foo')).to be false
     end
 
     it 'is false for less than' do


### PR DESCRIPTION
The `nodes` key has been removed from the partitions syntax and replaced with a `list` matcher:

```
partitions:
  - name: nodes
    node_matchers:
      name:
        list: [node01, node02, node03]
```

The `list` matcher broadly work the same as the other matchers and also supports integers.
NOTE: It was easier to support integer matches than exclude them. It part of the formal specification.

```
partitions:
  - name: nodes
    node_matchers:
      cpus:
        list: [1,3,5,8]
```

As the matchers are only ran when a node joins, the "listed by name" nodes no longer appear in the `info` command by default:

```
[root@master scheduler]# bin/scheduler info
┌───────────┬───────┬───────────┬───────┬────────┬──────────┐
│ PARTITION │ AVAIL │ TIMELIMIT │ NODES │ STATE  │ NODELIST │
├───────────┼───────┼───────────┼───────┼────────┼──────────┤
│ all       │ up    │ 1-1:0:0   │ 0     │ (none) │ (none)   │
│ nodes     │ up    │ (none)    │ 0     │ (none) │ (none)   │
└───────────┴───────┴───────────┴───────┴────────┴──────────┘
```

Instead they are added the first time they join the cluster. This could be solved in a few different ways, but was considered out of scope of this PR.