### PR TITLE
Introduce a CONFIGURED state after a job has been allocated

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -347,11 +347,6 @@ class App < Sinatra::Base
       # Long poll until the resource is no longer pending or timeout.
       task = Async do |t|
         t.with_timeout(FlightScheduler.app.config.polling_timeout) do
-          # TODO: Previously the configuring state was part of pending
-          #       and would block this long poll.
-          #
-          # Consider refactoring to change the name of the flag. Blocking
-          # on both is still the desired behaviour
           while resource.pending? || resource.configuring? do
             t.sleep FlightScheduler.app.config.generic_short_sleep.to_f
           end

--- a/app.rb
+++ b/app.rb
@@ -347,7 +347,12 @@ class App < Sinatra::Base
       # Long poll until the resource is no longer pending or timeout.
       task = Async do |t|
         t.with_timeout(FlightScheduler.app.config.polling_timeout) do
-          while resource.pending? do
+          # TODO: Previously the configuring state was part of pending
+          #       and would block this long poll.
+          #
+          # Consider refactoring to change the name of the flag. Blocking
+          # on both is still the desired behaviour
+          while resource.pending? || resource.configuring? do
             t.sleep FlightScheduler.app.config.generic_short_sleep.to_f
           end
         end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -54,7 +54,7 @@ class Job
     Resources
     WaitingForScheduling
   ).freeze
-  STATES = %w( PENDING RUNNING CANCELLING CANCELLED COMPLETED FAILED TIMINGOUT TIMEOUT ).freeze
+  STATES = %w( PENDING CONFIGURING RUNNING CANCELLING CANCELLED COMPLETED FAILED TIMINGOUT TIMEOUT ).freeze
   # NOTE: If adding new states to TERMINAL_STATES, `update_array_job_state`
   # will need updating too.
   TERMINAL_STATES = %w( CANCELLED COMPLETED FAILED TIMEOUT ).freeze

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -204,8 +204,8 @@ class FlightScheduler::AllocationRegistry
     max_jobs
   end
 
-  # NOTE: This method MUST not be called alone! The AllocationRegistry must be saved in
-  #       tandem with the JobRegistry. Failure to do so can lead to an inconsistent state
+  # NOTE: This method SHOULD NOT be called alone! The AllocationRegistry should be saved in
+  #       tandem with the JobRegistry. Failure to do so MAY lead to an inconsistent state
   def save
     @lock.with_read_lock do
       allocations = @node_allocations.values.flatten

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -93,17 +93,6 @@ class FlightScheduler::AllocationRegistry
       # Duplicate the allocation so it is safe to modify
       allocation = allocation.dup
 
-      # NOTE: Updating the state of the internal job object violates the Law of Demeter
-      #       as the registry needs to "reach through" the allocation first.
-      #
-      #       Whilst not ideal, it is important the AllocationRegistry and CONFIGURING
-      #       state stay in sync with each other.
-      #
-      #       Consider refactoring to do the following:
-      #       1. Infer the Job's state directly from the registry, or
-      #       2. Change add(allocation) to build(job, nodes). This would likely require
-      #          the use of 'Reservations' instead of 'Allocations' in the scheduler
-      allocation.job.state = 'CONFIGURING' if allocation.job.pending?
       allocation.nodes.each do |node|
         @node_allocations[node.name] << allocation
       end

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -92,11 +92,11 @@ module FlightScheduler
       Concurrent::TimerTask.new(**opts) do
         Async.logger.debug("Running cleanup periodic processor")
         job_registry.remove_old_jobs
-        job_registry.save
         job_registry.jobs_in_state(Job::TERMINAL_STATES).each do |job|
           Async.logger.debug("Removing allocation for job in terminal state: id=#{job.display_id} state=#{job.state}")
           FlightScheduler::Deallocation::Job.new(job).call
         end
+        job_registry.save
         allocations.save
         Async.logger.debug("Done running cleaup periodic processor")
       end.execute

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -89,6 +89,13 @@ module FlightScheduler::EventProcessor
       Async.logger.info("Allocated #{allocated_node_names} to job #{allocation.job.display_id}")
       FlightScheduler::Submission::Job.new(allocation).call
     end
+
+    # The allocation/job registries are coupled due to the job's state. A job that is in the
+    # CONFIGURING or RUNNING state must have an allocation and vice-versa
+    #
+    # Saving the two registries independently means this update can not be done in a transaction.
+    # Considering refactoring to save all registries as single file, or infer the state via some
+    # other means.
     FlightScheduler.app.job_registry.save
     FlightScheduler.app.allocations.save
   end
@@ -207,7 +214,7 @@ module FlightScheduler::EventProcessor
       Async.logger.info("Cancelling pending job #{job.display_id}")
       job.state = 'CANCELLED'
       allocate_resources_and_run_jobs
-    when 'RUNNING', 'CANCELLING'
+    when 'CONFIGURING', 'RUNNING', 'CANCELLING'
       Async.logger.info("Cancelling running job #{job.display_id}")
       FlightScheduler::Cancellation::Job.new(job).call
     else

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -162,6 +162,7 @@ module FlightScheduler::EventProcessor
     execution.state = 'RUNNING'
     execution.port = port
     FlightScheduler.app.job_registry.save
+    FlightScheduler.app.allocations.save
   end
   module_function :job_step_started
 
@@ -172,6 +173,7 @@ module FlightScheduler::EventProcessor
     execution = job_step.execution_for(node_name)
     execution.state = 'COMPLETED'
     FlightScheduler.app.job_registry.save
+    FlightScheduler.app.allocations.save
   end
   module_function :job_step_completed
 
@@ -182,6 +184,7 @@ module FlightScheduler::EventProcessor
     execution = job_step.execution_for(node_name)
     execution.state = 'FAILED'
     FlightScheduler.app.job_registry.save
+    FlightScheduler.app.allocations.save
   end
   module_function :job_step_failed
 

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -137,8 +137,8 @@ class FlightScheduler::JobRegistry
     raise
   end
 
-  # NOTE: This method MUST not be called alone! The JobRegistry must be saved in
-  #       tandem with the AllocationRegistry. Failure to ndo so can lead to an
+  # NOTE: This method SHOULD NOT be called alone! The JobRegistry should be saved in
+  #       tandem with the AllocationRegistry. Failure to do so MAY lead to an
   #       inconsistent state
   def save
     persistence.save(jobs.map(&:serializable_hash))

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -137,6 +137,9 @@ class FlightScheduler::JobRegistry
     raise
   end
 
+  # NOTE: This method MUST not be called alone! The JobRegistry must be saved in
+  #       tandem with the AllocationRegistry. Failure to ndo so can lead to an
+  #       inconsistent state
   def save
     persistence.save(jobs.map(&:serializable_hash))
   end

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -110,9 +110,11 @@ class FlightScheduler::JobRegistry
     end
   end
 
+  # NOTE: This method is a misnomer, it includes jobs which may not have started but will
+  # imminently. Consider refactoring
   def running_tasks_for(job)
     tasks_for(job).select do |task|
-      task.running? || (task.allocated? && task.pending?)
+      task.running? || task.configuring?
     end
   end
 

--- a/lib/flight_scheduler/schedulers/base_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/base_scheduler.rb
@@ -185,7 +185,7 @@ class BaseScheduler
 
   def schedule_event_scripts(partition)
     has_insufficient_resources = queue(partition).any? do |job|
-      job.reason_pending == 'Resources'
+      ['Resources', 'PartitionNodeLimit'].include? job.reason_pending
     end
     if has_insufficient_resources
       partition.script_runner.insufficient

--- a/lib/flight_scheduler/schedulers/base_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/base_scheduler.rb
@@ -184,11 +184,8 @@ class BaseScheduler
   end
 
   def schedule_event_scripts(partition)
-    # Work around an issue with job states not being sufficiently expressive.
-    # We need a new job state between PENDING and RUNNING which captures that
-    # the job has been allocated but the daemons have not yet been informed.
     has_insufficient_resources = queue(partition).any? do |job|
-      !job.allocated? && job.reason_pending == 'Resources'
+      job.reason_pending == 'Resources'
     end
     if has_insufficient_resources
       partition.script_runner.insufficient

--- a/lib/flight_scheduler/schedulers/base_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/base_scheduler.rb
@@ -122,6 +122,7 @@ class BaseScheduler
         end
         FlightScheduler.app.allocations.add(allocation)
         job.start_time = Time.now
+        job.state = 'CONFIGURING'
         allocation
       end
     end

--- a/lib/flight_scheduler/schedulers/base_scheduler.rb
+++ b/lib/flight_scheduler/schedulers/base_scheduler.rb
@@ -122,7 +122,6 @@ class BaseScheduler
         end
         FlightScheduler.app.allocations.add(allocation)
         job.start_time = Time.now
-        job.state = 'CONFIGURING'
         allocation
       end
     end
@@ -142,7 +141,7 @@ class BaseScheduler
 
     Enumerator.new do |yielder|
       queue(partition).each do |job|
-        next unless job.pending? && job.allocation.nil?
+        next unless job.pending?
         max_time_limit = job.partition.max_time_limit
         if max_time_limit.nil?
           # NOOP

--- a/lib/flight_scheduler/submission/job.rb
+++ b/lib/flight_scheduler/submission/job.rb
@@ -36,13 +36,10 @@ module FlightScheduler::Submission
       @allocation.nodes.each do |node|
         initialize_job_on(node)
       end
-      # XXX Should a job transition to RUNNING after all the daemons have been
-      #     notified? Currently the daemons do not report back "job received",
-      #     so doing so reliable is not possible
-      @job.state = 'RUNNING'
       if @job.has_batch_script?
         run_batch_script_on(@allocation.nodes.first)
       end
+      @job.state = 'RUNNING'
     rescue
       # XXX What to do here for UnconnectedNode errors?
       # 1. abort/cancel the job
@@ -50,6 +47,7 @@ module FlightScheduler::Submission
       # 3. something else?
       #
       # XXX What to do for other errors?
+      # * What if the batch script fails?
       # * Cancel the job on any nodes?
       # * Remove the allocation?
       # * Remove the job from the scheduler?

--- a/lib/flight_scheduler/submission/job.rb
+++ b/lib/flight_scheduler/submission/job.rb
@@ -33,10 +33,13 @@ module FlightScheduler::Submission
     end
 
     def call
-      @job.state = 'RUNNING'
       @allocation.nodes.each do |node|
         initialize_job_on(node)
       end
+      # XXX Should a job transition to RUNNING after all the daemons have been
+      #     notified? Currently the daemons do not report back "job received",
+      #     so doing so reliable is not possible
+      @job.state = 'RUNNING'
       if @job.has_batch_script?
         run_batch_script_on(@allocation.nodes.first)
       end

--- a/libexec/slack.sh
+++ b/libexec/slack.sh
@@ -102,7 +102,7 @@ fi
 
 # Unpacks the JSON input contained within STDIN
 json=$(cat <&0)
-running=$(echo "$json" | jq '.jobs | with_entries(select(.value | .state == "RUNNING"))')
+running=$(echo "$json" | jq '.jobs | with_entries(select(.value | (.state == "RUNNING") or (.state == "CONFIGURING")))')
 pending=$(echo "$json" | jq '.jobs | with_entries(select(.value | .state == "PENDING"))')
 resources=$(echo "$json" | jq '.jobs | with_entries(select(.value | .reason == "Resources"))')
 

--- a/spec/schedulers/shared_scheduler_spec.rb
+++ b/spec/schedulers/shared_scheduler_spec.rb
@@ -40,6 +40,7 @@ RSpec.shared_examples 'basic scheduler specs' do
     end
 
     def add_allocation(job, nodes)
+      job.state = 'CONFIGURING'
       build(:allocation, job: job, nodes: nodes).tap do |allocation|
         allocations.add(allocation)
       end


### PR DESCRIPTION
The new `CONFIGURED` state is used to differentiate jobs which have been allocated but not started.

This also adds the new `configured?` method to jobs, which is similar but not analogous to `allocated?`. The `allocated?` method checks if an `Allocation` exists for a job. Where the `configured?` method is only true for jobs which have an `Allocation` which aren't `RUNNING`/`CANCELLING` etc.

In practice there is only a brief window where the jobs are in this state. The jobs are started immediately after allocation and transition to `RUNNING`. Currently the daemons do not report back if they have received the job so are unlikely to block the "start" message. This may change in the future.

I have manually confirmed the new `CONFIGURED` state can be displayed by the client. This was difficult to reproduce and required code alterations to slow down the controllers execution. These changes have not been committed.