### PR TITLE
Share a persistence between the JobRegistry and AllocationRegistry

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -36,7 +36,7 @@ class Allocation
 
   def self.from_serialized_hash(hash)
     new(
-      job: FlightScheduler.app.job_registry.lookup(hash['job_id']),
+      job: FlightScheduler.app.job_registry.lookup(hash['job_id'], with_lock: false),
       node_names: hash['node_names'],
     )
   end

--- a/config/initializers/persistence.rb
+++ b/config/initializers/persistence.rb
@@ -26,7 +26,6 @@
 #==============================================================================
 
 unless FlightScheduler.env.test?
-  FlightScheduler.app.job_registry.load
-  FlightScheduler.app.allocations.load
+  FlightScheduler.app.load_scheduler_state
   FlightScheduler.app.init_periodic_processors
 end

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -61,12 +61,7 @@ module FlightScheduler
   end
 
   def app
-    @app ||= Application.new(
-      allocations: AllocationRegistry.new,
-      daemon_connections: DaemonConnections.new,
-      job_registry: JobRegistry.new,
-      schedulers: Schedulers.new,
-    )
+    @app ||= Application::Builder.build_app
   end
   module_function :app
 

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -62,7 +62,7 @@ module FlightScheduler
   end
 
   def app
-    @app ||= Application::Builder.build_app
+    @app ||= Application.build
   end
   module_function :app
 

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -43,7 +43,7 @@ module FlightScheduler
   autoload(:Persistence, 'flight_scheduler/persistence')
   autoload(:RangeExpander, 'flight_scheduler/range_expander')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
-  autoload(:SharedJobAllocationPersistence, 'flight_scheduler/shared_job_allocation_persistence')
+  autoload(:SchedulerState, 'flight_scheduler/scheduler_state')
   autoload(:TimeResolver, 'flight_scheduler/time_resolver')
 
   module Cancellation

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -43,6 +43,7 @@ module FlightScheduler
   autoload(:Persistence, 'flight_scheduler/persistence')
   autoload(:RangeExpander, 'flight_scheduler/range_expander')
   autoload(:Schedulers, 'flight_scheduler/schedulers')
+  autoload(:SharedJobAllocationPersistence, 'flight_scheduler/shared_job_allocation_persistence')
   autoload(:TimeResolver, 'flight_scheduler/time_resolver')
 
   module Cancellation

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -256,11 +256,6 @@ class FlightScheduler::AllocationRegistry
     raise "The Allocation Registry has not been initialized with a persistence!"
   end
 
-  def persistence
-    @persistence ||= FlightScheduler::Persistence
-      .new('allocation registry', 'allocation_state')
-  end
-
   # These methods exist to facilitate testing.
 
   def empty?

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -51,7 +51,8 @@ class FlightScheduler::AllocationRegistry
     memory: :memory_per_node
   }
 
-  def initialize
+  def initialize(shared_persistence: nil)
+    @shared_persistence = shared_persistence
     @node_allocations = Hash.new { |h, k| h[k] = [] }
     @job_allocations  = {}
     @lock = Concurrent::ReadWriteLock.new
@@ -203,7 +204,7 @@ class FlightScheduler::AllocationRegistry
   end
 
   def load
-    data = persistence.load
+    data = shared_persistence.load_allocations
     return if data.nil?
     @lock.with_write_lock do
       allocations = data.map do |h|
@@ -245,6 +246,12 @@ class FlightScheduler::AllocationRegistry
     KEY_MAP.values.each_with_object({}) do |key, memo|
       memo[key] = allocations.map { |a| a.job.send(key).to_i }.reduce(&:+).to_i
     end
+  end
+
+  # NOTE: Allows the registry to be created within the specs without the persistence
+  def shared_persistence
+    return @shared_persistence if @shared_persistence
+    raise "The Allocation Registry has not been initialized with a persistence!"
   end
 
   def persistence

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -200,11 +200,6 @@ class FlightScheduler::AllocationRegistry
     end
   end
 
-  # DEPRECATED: The shared registry should be saved directly
-  def save
-    shared_persistence.save
-  end
-
   def load
     data = shared_persistence.load_allocations
     return if data.nil?

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -194,13 +194,15 @@ class FlightScheduler::AllocationRegistry
     max_jobs
   end
 
-  # NOTE: This method SHOULD NOT be called alone! The AllocationRegistry should be saved in
-  #       tandem with the JobRegistry. Failure to do so MAY lead to an inconsistent state
-  def save
+  def serializable_data
     @lock.with_read_lock do
-      allocations = @node_allocations.values.flatten
-      persistence.save(allocations.map(&:serializable_hash))
+      @node_allocations.values.flatten.map(&:serializable_hash)
     end
+  end
+
+  # DEPRECATED: The shared registry should be saved directly
+  def save
+    shared_persistence.save
   end
 
   def load

--- a/lib/flight_scheduler/allocation_registry.rb
+++ b/lib/flight_scheduler/allocation_registry.rb
@@ -51,11 +51,11 @@ class FlightScheduler::AllocationRegistry
     memory: :memory_per_node
   }
 
-  def initialize(shared_persistence: nil)
+  def initialize(shared_persistence: nil, lock: nil)
     @shared_persistence = shared_persistence
     @node_allocations = Hash.new { |h, k| h[k] = [] }
     @job_allocations  = {}
-    @lock = Concurrent::ReadWriteLock.new
+    @lock = lock || Concurrent::ReadWriteLock.new
   end
 
   def add(allocation)

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -36,21 +36,20 @@ module FlightScheduler
         self.new.app
       end
 
-      attr_reader :allocations, :daemon_connections, :job_registry, :schedulers
-
       def initialize
-        @allocations = AllocationRegistry.new
+        shared_persistence = SharedJobAllocationPersistence.new
+        @allocations = shared_persistence.allocations
         @daemon_connections = DaemonConnections.new
-        @job_registry = JobRegistry.new
+        @job_registry = shared_persistence.jobs
         @schedulers = Schedulers.new
       end
 
       def app
         @app ||= Application.new(
-          allocations: allocations,
-          daemon_connections: daemon_connections,
-          job_registry: job_registry,
-          schedulers: schedulers
+          allocations: @allocations,
+          daemon_connections: @daemon_connections,
+          job_registry: @job_registry,
+          schedulers: @schedulers
         )
       end
     end

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -31,6 +31,29 @@ module FlightScheduler
   # Class to store configuration and provide a singleton resource to lookup
   # that configuration.  Similar in nature to `Rails.app`.
   class Application
+    class Builder
+      def self.build_app
+        self.new.app
+      end
+
+      attr_reader :allocations, :daemon_connections, :job_registry, :schedulers
+
+      def initialize
+        @allocations = AllocationRegistry.new
+        @daemon_connections = DaemonConnections.new
+        @job_registry = JobRegistry.new
+        @schedulers = Schedulers.new
+      end
+
+      def app
+        @app ||= Application.new(
+          allocations: allocations,
+          daemon_connections: daemon_connections,
+          job_registry: job_registry,
+          schedulers: schedulers
+        )
+      end
+    end
 
     attr_reader :allocations
     attr_reader :daemon_connections

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -31,28 +31,20 @@ module FlightScheduler
   # Class to store configuration and provide a singleton resource to lookup
   # that configuration.  Similar in nature to `Rails.app`.
   class Application
-    class Builder
-      def self.build_app
-        self.new.app
-      end
+    def self.build
+      scheduler_state = SchedulerState.new
+      allocations = scheduler_state.allocations
+      job_registry = scheduler_state.jobs
+      daemon_connections = DaemonConnections.new
+      schedulers = Schedulers.new
 
-      def initialize
-        @scheduler_state = SchedulerState.new
-        @allocations = @scheduler_state.allocations
-        @daemon_connections = DaemonConnections.new
-        @job_registry = @scheduler_state.jobs
-        @schedulers = Schedulers.new
-      end
-
-      def app
-        @app ||= Application.new(
-          scheduler_state: @scheduler_state,
-          allocations: @allocations,
-          daemon_connections: @daemon_connections,
-          job_registry: @job_registry,
-          schedulers: @schedulers
-        )
-      end
+      Application.new(
+        scheduler_state: scheduler_state,
+        allocations: allocations,
+        daemon_connections: daemon_connections,
+        job_registry: job_registry,
+        schedulers: schedulers
+      )
     end
 
     attr_reader :allocations
@@ -61,8 +53,13 @@ module FlightScheduler
     attr_reader :schedulers
     attr_reader :nodes
 
-    def initialize(allocations:, daemon_connections:, job_registry:, schedulers:,
-                   scheduler_state:)
+    def initialize(
+      allocations:,
+      daemon_connections:,
+      job_registry:,
+      schedulers:,
+      scheduler_state: 
+    )
       @scheduler_state = scheduler_state
       @allocations = allocations
       @daemon_connections = daemon_connections

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -37,16 +37,16 @@ module FlightScheduler
       end
 
       def initialize
-        @shared_persistence = SharedJobAllocationPersistence.new
-        @allocations = @shared_persistence.allocations
+        @scheduler_state = SchedulerState.new
+        @allocations = @scheduler_state.allocations
         @daemon_connections = DaemonConnections.new
-        @job_registry = @shared_persistence.jobs
+        @job_registry = @scheduler_state.jobs
         @schedulers = Schedulers.new
       end
 
       def app
         @app ||= Application.new(
-          shared_job_allocation_persistence: @shared_persistence,
+          scheduler_state: @scheduler_state,
           allocations: @allocations,
           daemon_connections: @daemon_connections,
           job_registry: @job_registry,
@@ -62,8 +62,8 @@ module FlightScheduler
     attr_reader :nodes
 
     def initialize(allocations:, daemon_connections:, job_registry:, schedulers:,
-                   shared_job_allocation_persistence:)
-      @shared_job_allocation_persistence = shared_job_allocation_persistence
+                   scheduler_state:)
+      @scheduler_state = scheduler_state
       @allocations = allocations
       @daemon_connections = daemon_connections
       @job_registry = job_registry
@@ -84,7 +84,11 @@ module FlightScheduler
     end
 
     def persist_scheduler_state
-      @shared_job_allocation_persistence.save
+      @scheduler_state.save
+    end
+
+    def load_scheduler_state
+      @scheduler_state.load
     end
 
     def partitions

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -83,7 +83,7 @@ module FlightScheduler
         end
     end
 
-    def save_job_and_allocation_registries
+    def persist_scheduler_state
       @shared_job_allocation_persistence.save
     end
 
@@ -125,7 +125,7 @@ module FlightScheduler
           Async.logger.debug("Removing allocation for job in terminal state: id=#{job.display_id} state=#{job.state}")
           FlightScheduler::Deallocation::Job.new(job).call
         end
-        save_job_and_allocation_registries
+        persist_scheduler_state
         Async.logger.debug("Done running cleaup periodic processor")
       end.execute
 

--- a/lib/flight_scheduler/event_processor.rb
+++ b/lib/flight_scheduler/event_processor.rb
@@ -89,7 +89,7 @@ module FlightScheduler::EventProcessor
       Async.logger.info("Allocated #{allocated_node_names} to job #{allocation.job.display_id}")
       FlightScheduler::Submission::Job.new(allocation).call
     end
-    FlightScheduler.app.save_job_and_allocation_registries
+    FlightScheduler.app.persist_scheduler_state
   end
   module_function :allocate_resources_and_run_jobs
 
@@ -153,7 +153,7 @@ module FlightScheduler::EventProcessor
     execution = job_step.execution_for(node_name)
     execution.state = 'RUNNING'
     execution.port = port
-    FlightScheduler.app.save_job_and_allocation_registries
+    FlightScheduler.app.persist_scheduler_state
   end
   module_function :job_step_started
 
@@ -163,7 +163,7 @@ module FlightScheduler::EventProcessor
     Async.logger.info("Node #{node_name} completed step #{job_step.display_id}")
     execution = job_step.execution_for(node_name)
     execution.state = 'COMPLETED'
-    FlightScheduler.app.save_job_and_allocation_registries
+    FlightScheduler.app.persist_scheduler_state
   end
   module_function :job_step_completed
 
@@ -173,7 +173,7 @@ module FlightScheduler::EventProcessor
     Async.logger.info("Node #{node_name} failed step #{job_step.display_id}")
     execution = job_step.execution_for(node_name)
     execution.state = 'FAILED'
-    FlightScheduler.app.save_job_and_allocation_registries
+    FlightScheduler.app.persist_scheduler_state
   end
   module_function :job_step_failed
 

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -172,10 +172,6 @@ class FlightScheduler::JobRegistry
     raise "The Job Registry has not been initialized with a persistence!"
   end
 
-  def persistence
-    @persistence ||= FlightScheduler::Persistence.new('job registry', 'job_state')
-  end
-
   # These methods exist to facilitate testing.
   def clear
     @lock.with_write_lock do

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -144,11 +144,6 @@ class FlightScheduler::JobRegistry
     end
   end
 
-  # DEPRECATED: The shared registry should be saved directly
-  def save
-    shared_persistence.save
-  end
-
   private
 
   def delete(job_or_job_id)

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -34,9 +34,9 @@ require 'concurrent'
 class FlightScheduler::JobRegistry
   class DuplicateJob < RuntimeError; end
 
-  def initialize(shared_persistence: nil)
+  def initialize(shared_persistence: nil, lock: nil)
     @shared_persistence = shared_persistence
-    @lock = Concurrent::ReadWriteLock.new
+    @lock = lock || Concurrent::ReadWriteLock.new
 
     # Map of job id to job.
     # NOTE: Hashes enumerate their values in the order that the corresponding

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -138,11 +138,15 @@ class FlightScheduler::JobRegistry
     raise
   end
 
-  # NOTE: This method SHOULD NOT be called alone! The JobRegistry should be saved in
-  #       tandem with the AllocationRegistry. Failure to do so MAY lead to an
-  #       inconsistent state
+  def serializable_data
+    @lock.with_read_lock do
+      jobs.map(&:serializable_hash)
+    end
+  end
+
+  # DEPRECATED: The shared registry should be saved directly
   def save
-    persistence.save(jobs.map(&:serializable_hash))
+    shared_persistence.save
   end
 
   private

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -84,8 +84,12 @@ class FlightScheduler::JobRegistry
     end
   end
 
-  def [](job_id)
-    @lock.with_read_lock do
+  def [](job_id, with_lock: true)
+    if with_lock
+      @lock.with_read_lock do
+        @jobs[job_id]
+      end
+    else
       @jobs[job_id]
     end
   end

--- a/lib/flight_scheduler/node_registry.rb
+++ b/lib/flight_scheduler/node_registry.rb
@@ -55,6 +55,9 @@ class FlightScheduler::NodeRegistry
         node = @nodes[node_name] = Node.new(name: node_name)
       end
       update_partition_cache(node)
+
+      # Return the node
+      node
     end
   end
 

--- a/lib/flight_scheduler/node_registry.rb
+++ b/lib/flight_scheduler/node_registry.rb
@@ -55,8 +55,6 @@ class FlightScheduler::NodeRegistry
         node = @nodes[node_name] = Node.new(name: node_name)
       end
       update_partition_cache(node)
-
-      # Return the node
       node
     end
   end
@@ -80,8 +78,6 @@ class FlightScheduler::NodeRegistry
           Async.logger.debug "Ignoring node '#{node.name}' for partition '#{partition.name}'"
         end
       end
-
-      # Return the node
     end
   end
 

--- a/lib/flight_scheduler/node_registry.rb
+++ b/lib/flight_scheduler/node_registry.rb
@@ -79,7 +79,6 @@ class FlightScheduler::NodeRegistry
       end
 
       # Return the node
-      node
     end
   end
 

--- a/lib/flight_scheduler/shared_job_allocation_persistence.rb
+++ b/lib/flight_scheduler/shared_job_allocation_persistence.rb
@@ -1,0 +1,53 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerController.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerController is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerController. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerController, please visit:
+# https://github.com/openflighthpc/flight-scheduler-controller
+#==============================================================================
+
+module FlightScheduler
+  class SharedJobAllocationPersistence
+    attr_reader :jobs, :allocations
+
+    def initialize
+      @jobs = JobRegistry.new(shared_persistence: self)
+      @allocations = AllocationRegistry.new(shared_persistence: self)
+    end
+
+    def persistence
+      @persistence ||= FlightScheduler::Persistence.new('job/allocation registries', 'job_and_allocation_state')
+    end
+
+    def load_allocations
+      data = persistence.load
+      return if data.nil?
+      data['allocations']
+    end
+
+    def load_jobs
+      data = persistence.load
+      return if data.nil?
+      data['jobs']
+    end
+  end
+end

--- a/lib/flight_scheduler/shared_job_allocation_persistence.rb
+++ b/lib/flight_scheduler/shared_job_allocation_persistence.rb
@@ -50,5 +50,15 @@ module FlightScheduler
       return if data.nil?
       data['jobs']
     end
+
+    def save
+      @lock.with_read_lock do
+        data = {
+          'allocations' => allocations.serializable_data,
+          'jobs'        => jobs.serializable_data
+        }
+        persistence.save(data)
+      end
+    end
   end
 end

--- a/lib/flight_scheduler/shared_job_allocation_persistence.rb
+++ b/lib/flight_scheduler/shared_job_allocation_persistence.rb
@@ -30,8 +30,9 @@ module FlightScheduler
     attr_reader :jobs, :allocations
 
     def initialize
-      @jobs = JobRegistry.new(shared_persistence: self)
-      @allocations = AllocationRegistry.new(shared_persistence: self)
+      @lock = Concurrent::ReadWriteLock.new
+      @jobs = JobRegistry.new(shared_persistence: self, lock: @lock)
+      @allocations = AllocationRegistry.new(shared_persistence: self, lock: @lock)
     end
 
     def persistence


### PR DESCRIPTION
Due to the coupling between the allocations and jobs, their persistence need to stay in sync. This is best achieved by saving their data in the same file.

This has been achieved by adding a `SharedJobAllocationPersistence` object. This contains a single underlining `Persistence` which saves the data to the file. It also implements the following methods:

* `load_allocations` fetches the allocations data,
* `load_jobs` fetches the jobs data, and
* `save` which saves both the `AllocationRegistry` and `JobRegistry`

For this mechanism to work, the new shared persistence needs to keep track of both registries. This is done without referencing the `FlightScheduler.app` singleton model. This was done for two reasons:

1. It prevents newly initialised versions of the registries dynamically linking against the global value (mostly an issue in the specs), and
2. It allows the two registries and the persistence to share a `lock`.

The persistence and registries need to share a lock to prevent either object being updated whilst the persistence is being saved. This guarantees consistency between the registries.

A few other more minor changes have been made:

1. `allocations` are deserialized without a `read_lock` as this occurs in a `write_lock`,
2. An `Application::Builder` has been added to create the linked registries, and
3. A bug fix to allow daemons to register nodes without erroring.